### PR TITLE
Add PEG grammar and comprehensive parser tests for CoHDL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "cohdl-cli"
 version = "0.1.0"
 
@@ -21,6 +36,10 @@ version = "0.1.0"
 [[package]]
 name = "cohdl-parser"
 version = "0.1.0"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
 
 [[package]]
 name = "cohdl-sema"
@@ -29,3 +48,161 @@ version = "0.1.0"
 [[package]]
 name = "cohdl-syntax"
 version = "0.1.0"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/conol/cohdl"
 
 [workspace.dependencies]
+pest = "2.7"
+pest_derive = "2.7"

--- a/crates/cohdl-parser/Cargo.toml
+++ b/crates/cohdl-parser/Cargo.toml
@@ -3,3 +3,10 @@ name = "cohdl-parser"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+
+[dependencies]
+pest = { workspace = true }
+pest_derive = { workspace = true }
+
+[dev-dependencies]
+pest = { workspace = true }

--- a/crates/cohdl-parser/src/grammar.pest
+++ b/crates/cohdl-parser/src/grammar.pest
@@ -1,0 +1,228 @@
+// ──────────────────────────────────────────────
+// cohdl PEG grammar  (pest 2.x)
+// ──────────────────────────────────────────────
+
+// ── Implicit whitespace & comments ──────────
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
+COMMENT    = _{ "//" ~ (!NEWLINE ~ ANY)* }
+
+// ── File ────────────────────────────────────
+file = { SOI ~ top_level_item* ~ EOI }
+
+// ── Top-level items ─────────────────────────
+top_level_item = {
+    attribute* ~ visibility? ~ (
+        trait_def
+      | device_def
+      | part_def
+      | type_def
+      | fn_def
+      | module_def
+      | design_def
+      | use_decl
+      | mod_decl
+    )
+}
+
+visibility = { "pub" }
+
+// ── Attributes ──────────────────────────────
+attribute      = { "#[" ~ attribute_inner ~ "]" }
+attribute_inner = { ident ~ ("(" ~ attribute_args ~ ")")? }
+attribute_args  = { string_literal ~ ("," ~ string_literal)*
+                  | ident ~ ("," ~ ident)* }
+
+// ── Use declaration ─────────────────────────
+use_decl  = { "use" ~ use_path }
+use_path  = { ident ~ ("::" ~ (use_group | ident))* }
+use_group = { "{" ~ ident ~ ("," ~ ident)* ~ ","? ~ "}" }
+
+// ── Module declaration (pub mod / mod) ──────
+mod_decl = { "mod" ~ ident }
+
+// ── Identifiers & paths ────────────────────
+ident       = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+scoped_path =  { ident ~ ("::" ~ ident)+ }
+
+// ── Literals ────────────────────────────────
+// Engineering-notation number: 100nF  10k  3.3V  48  22R  100m  4.7uF  6.3V  0.8
+eng_number = @{
+    ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? ~ eng_suffix?
+}
+eng_suffix = @{ (ASCII_ALPHA)+ }
+
+integer = @{ ASCII_DIGIT+ }
+
+string_literal = @{ "\"" ~ string_inner ~ "\"" }
+string_inner   = @{ (!"\"" ~ !"\\" ~ ANY | "\\" ~ ANY)* }
+
+boolean = { "true" | "false" }
+
+// ── Pin values ──────────────────────────────
+pin_value = { pin_range | pin_list | integer }
+pin_list  = { "[" ~ integer ~ ("," ~ integer)* ~ "]" }
+pin_range = { "[" ~ integer ~ ".." ~ integer ~ "]" }
+
+// ── Pin-bus macro call ──────────────────────
+pin_bus_call = { "pin_bus!" ~ "(" ~ ident ~ "," ~ integer ~ "," ~ integer ~ ")" }
+
+// ── Generic parameters (definition site) ───
+generic_params   = { "<" ~ generic_param_def ~ ("," ~ generic_param_def)* ~ ">" }
+generic_param_def = { ident ~ ":" ~ (impl_constraint | type_expr) ~ ("=" ~ value_expr)? }
+
+impl_constraint = { "impl" ~ trait_bound }
+trait_bound      = { type_expr ~ ("+" ~ type_expr)* }
+
+// ── Generic arguments (usage site) ──────────
+generic_args = { "<" ~ generic_arg ~ ("," ~ generic_arg)* ~ ">" }
+generic_arg  = { ident ~ ":" ~ value_expr }
+
+// ── Type expression ─────────────────────────
+type_expr = { (scoped_path | ident) ~ generic_args? }
+
+// ── Value expression ────────────────────────
+// Used in generic defaults, spec values, inst types, call args, etc.
+value_expr = { expr }
+
+// ── Expression hierarchy (for rule bodies) ──
+expr            = { comparison_expr }
+comparison_expr = { additive_expr ~ (comparison_op ~ additive_expr)? }
+comparison_op   = { "<=" | ">=" | "!=" | "==" }
+additive_expr   = { multiplicative_expr ~ (additive_op ~ multiplicative_expr)* }
+additive_op     = { "+" | "-" }
+multiplicative_expr = { unary_expr ~ (multiplicative_op ~ unary_expr)* }
+multiplicative_op   = { "*" | "/" }
+unary_expr      = { unary_op? ~ atom_expr }
+unary_op        = { "-" | "!" }
+atom_expr       = { "(" ~ expr ~ ")"
+                   | boolean
+                   | eng_number
+                   | string_literal
+                   | fn_call_expr
+                   | dot_path
+                   | type_expr }
+
+// Dotted path: self.spec.voltage_rating, mcu.VDD_IO, c.A
+dot_path = { (scoped_path | ident) ~ ("." ~ ident)+ }
+
+// Function-call expression (inside rule assert, etc.)
+fn_call_expr = { (scoped_path | ident) ~ "(" ~ (fn_call_expr_arg ~ ("," ~ fn_call_expr_arg)*)? ~ ")" }
+fn_call_expr_arg = { expr }
+
+// ── Trait definition ────────────────────────
+trait_def = {
+    "trait" ~ ident ~ trait_parents? ~ "{" ~ trait_body_item* ~ "}"
+}
+trait_parents   = { ":" ~ type_expr ~ ("+" ~ type_expr)* }
+trait_body_item = {
+    pins_block
+  | spec_block
+  | rule_block
+  | designator_prefix
+}
+
+designator_prefix = { "designator_prefix" ~ ":" ~ string_literal }
+
+// ── Pins block ──────────────────────────────
+// pins { A: 1, B: 2 }                     — unqualified
+// pins[LQFP48] { ... }                   — package-qualified
+pins_block     = { "pins" ~ pins_qualifier? ~ "{" ~ (pin_entry ~ ","?)* ~ "}" }
+pins_qualifier = { "[" ~ ident ~ "]" }
+pin_entry      = { pin_bus_call | ident ~ ":" ~ pin_value_or_type }
+pin_value_or_type = { pin_value | ident }
+
+// ── Spec block ──────────────────────────────
+spec_block = { "spec" ~ "{" ~ (spec_entry ~ ","?)* ~ "}" }
+spec_entry = { ident ~ ":" ~ value_expr }
+
+// ── Rule block ──────────────────────────────
+rule_block     = { "rule" ~ ident ~ "(" ~ rule_level ~ ")" ~ "{" ~ rule_body ~ "}" }
+rule_level     = { "level" ~ ":" ~ ident }
+rule_body      = { rule_assert ~ rule_message }
+rule_assert    = { "assert" ~ expr }
+rule_message   = { "message" ~ ":" ~ interpolated_string }
+
+interpolated_string       = @{ "\"" ~ interpolated_string_inner ~ "\"" }
+interpolated_string_inner = @{
+    (
+        "{" ~ (!"}" ~ ANY)* ~ "}"
+      | !("\"" | "\\") ~ ANY
+      | "\\" ~ ANY
+    )*
+}
+
+// ── Device definition ───────────────────────
+device_def = {
+    "device" ~ ident ~ generic_params?
+    ~ impl_clause?
+    ~ "{" ~ device_body_item* ~ "}"
+}
+
+impl_clause = { ":" ~ "impl" ~ trait_bound }
+
+device_body_item = {
+    package_decl
+  | pins_block
+  | spec_block
+  | rule_block
+}
+
+package_decl = { "package" ~ ":" ~ (scoped_path | ident) }
+
+// ── Part definition ─────────────────────────
+part_def = {
+    "part" ~ ident ~ ":" ~ type_expr
+    ~ "{" ~ avl_entry* ~ "}"
+}
+
+avl_entry     = { avl_kind ~ "{" ~ (avl_field ~ ","?)* ~ "}" }
+avl_kind      = { "primary" | "alt" }
+avl_field     = { ident ~ ":" ~ string_literal }
+
+// ── Type alias ──────────────────────────────
+type_def = {
+    "type" ~ ident ~ generic_params? ~ "=" ~ type_expr
+}
+
+// ── Function definition ─────────────────────
+fn_def = {
+    "fn" ~ ident ~ generic_params?
+    ~ "(" ~ (fn_param ~ ("," ~ fn_param)*)? ~ ")"
+    ~ "{" ~ fn_body_stmt* ~ "}"
+}
+
+fn_param      = { ident ~ ":" ~ (impl_constraint | type_expr) }
+
+fn_body_stmt  = { attribute* ~ (inst_stmt | net_stmt | call_stmt) }
+
+// ── Module definition ───────────────────────
+module_def = {
+    "module" ~ ident ~ "{" ~ top_level_item* ~ "}"
+}
+
+// ── Design definition ───────────────────────
+design_def = {
+    "design" ~ ident ~ "{" ~ design_body_stmt* ~ "}"
+}
+
+design_body_stmt = { attribute* ~ (inst_stmt | net_stmt | call_stmt) }
+
+// ── Statements ──────────────────────────────
+// inst name: Type<...>
+// inst name: Type<...> { primary { ... } alt { ... } }
+inst_stmt = {
+    "inst" ~ ident ~ ":" ~ type_expr ~ ("{" ~ avl_entry* ~ "}")?
+}
+
+// net name: pin_ref, pin_ref, ...
+net_stmt = {
+    "net" ~ net_target ~ ":" ~ net_endpoint ~ ("," ~ net_endpoint)*
+}
+net_target   = { dot_path | ident }
+net_endpoint = { dot_path | ident }
+
+// Function call statement: name(arg: val, ...)  or  path::name(arg: val, ...)
+call_stmt = {
+    (scoped_path | ident) ~ "(" ~ (call_arg ~ ("," ~ call_arg)*)? ~ ")"
+}
+call_arg = { ident ~ ":" ~ value_expr }

--- a/crates/cohdl-parser/src/lib.rs
+++ b/crates/cohdl-parser/src/lib.rs
@@ -1,1 +1,8 @@
+use pest_derive::Parser;
 
+#[derive(Parser)]
+#[grammar = "grammar.pest"]
+pub struct CohdlParser;
+
+#[cfg(test)]
+mod tests;

--- a/crates/cohdl-parser/src/tests.rs
+++ b/crates/cohdl-parser/src/tests.rs
@@ -156,10 +156,7 @@ fn generic_params_with_defaults() {
 #[test]
 fn generic_params_impl_constraint() {
     assert_parses!(Rule::generic_params, "<P: impl Capacitor>");
-    assert_parses!(
-        Rule::generic_params,
-        "<P: impl Capacitor + Polarized>"
-    );
+    assert_parses!(Rule::generic_params, "<P: impl Capacitor + Polarized>");
 }
 
 #[test]
@@ -447,10 +444,7 @@ fn type_alias_no_params() {
         Rule::type_def,
         "type BypassCap = MLCC<C: 100nF, V: 10V, pkg: C0402>"
     );
-    assert_parses!(
-        Rule::type_def,
-        "type BulkCap = Tantalum<C: 10uF, V: 6.3V>"
-    );
+    assert_parses!(Rule::type_def, "type BulkCap = Tantalum<C: 10uF, V: 6.3V>");
     assert_parses!(
         Rule::type_def,
         "type PullupRes = Resistor<R: 10k, pkg: R0402>"
@@ -892,7 +886,10 @@ fn spec_block_values() {
 
 #[test]
 fn spec_block_comma_separated() {
-    assert_parses!(Rule::spec_block, "spec { capacitance: C, voltage_rating: V }");
+    assert_parses!(
+        Rule::spec_block,
+        "spec { capacitance: C, voltage_rating: V }"
+    );
 }
 
 #[test]

--- a/crates/cohdl-parser/src/tests.rs
+++ b/crates/cohdl-parser/src/tests.rs
@@ -1,0 +1,1469 @@
+use super::*;
+use pest::consumes_to;
+use pest::parses_to;
+use pest::Parser;
+
+// ─── Helper: assert a rule successfully parses input ───
+macro_rules! assert_parses {
+    ($rule:expr, $input:expr) => {
+        let input = $input.trim();
+        assert!(
+            CohdlParser::parse($rule, input).is_ok(),
+            "Failed to parse {:?} with rule {:?}:\n{}",
+            input,
+            $rule,
+            CohdlParser::parse($rule, input).unwrap_err()
+        );
+    };
+}
+
+macro_rules! assert_no_parse {
+    ($rule:expr, $input:expr) => {
+        assert!(
+            CohdlParser::parse($rule, $input).is_err(),
+            "Should NOT parse {:?} with rule {:?}",
+            $input,
+            $rule,
+        );
+    };
+}
+
+// ═══════════════════════════════════════════════
+// Identifiers & paths
+// ═══════════════════════════════════════════════
+
+#[test]
+fn ident_simple() {
+    assert_parses!(Rule::ident, "foo");
+    assert_parses!(Rule::ident, "_bar");
+    assert_parses!(Rule::ident, "VDD_IO");
+    assert_parses!(Rule::ident, "STM32F103");
+    assert_parses!(Rule::ident, "A");
+    assert_parses!(Rule::ident, "_internal_helper");
+}
+
+#[test]
+fn ident_rejects_leading_digit() {
+    assert_no_parse!(Rule::ident, "123abc");
+}
+
+#[test]
+fn scoped_path_basic() {
+    assert_parses!(Rule::scoped_path, "foo::bar");
+    assert_parses!(Rule::scoped_path, "power::decoupling");
+    assert_parses!(Rule::scoped_path, "passives::res_10k_0402");
+    assert_parses!(Rule::scoped_path, "stm32::STM32F103");
+    assert_parses!(Rule::scoped_path, "a::b::c");
+}
+
+// ═══════════════════════════════════════════════
+// Literals
+// ═══════════════════════════════════════════════
+
+#[test]
+fn eng_number_various() {
+    assert_parses!(Rule::eng_number, "100nF");
+    assert_parses!(Rule::eng_number, "10k");
+    assert_parses!(Rule::eng_number, "3.3V");
+    assert_parses!(Rule::eng_number, "48");
+    assert_parses!(Rule::eng_number, "22R");
+    assert_parses!(Rule::eng_number, "100m");
+    assert_parses!(Rule::eng_number, "4.7uF");
+    assert_parses!(Rule::eng_number, "6.3V");
+    assert_parses!(Rule::eng_number, "10uF");
+    assert_parses!(Rule::eng_number, "0.8");
+    assert_parses!(Rule::eng_number, "0.6");
+    assert_parses!(Rule::eng_number, "16V");
+}
+
+#[test]
+fn integer_basic() {
+    assert_parses!(Rule::integer, "1");
+    assert_parses!(Rule::integer, "48");
+    assert_parses!(Rule::integer, "0");
+    assert_parses!(Rule::integer, "12345");
+}
+
+#[test]
+fn string_literal_basic() {
+    assert_parses!(Rule::string_literal, r#""Samsung""#);
+    assert_parses!(Rule::string_literal, r#""CL05B104KO5NNNC""#);
+    assert_parses!(Rule::string_literal, r#""RC0402FR-0710KL""#);
+    assert_parses!(Rule::string_literal, r#""U1""#);
+    assert_parses!(Rule::string_literal, r#""""#);
+}
+
+#[test]
+fn boolean_literals() {
+    assert_parses!(Rule::boolean, "true");
+    assert_parses!(Rule::boolean, "false");
+}
+
+// ═══════════════════════════════════════════════
+// Pin values
+// ═══════════════════════════════════════════════
+
+#[test]
+fn pin_value_single() {
+    assert_parses!(Rule::pin_value, "1");
+    assert_parses!(Rule::pin_value, "48");
+}
+
+#[test]
+fn pin_value_list() {
+    assert_parses!(Rule::pin_list, "[1, 2, 3]");
+    assert_parses!(Rule::pin_list, "[8, 23, 35, 47]");
+    assert_parses!(Rule::pin_value, "[8, 23, 35, 47]");
+}
+
+#[test]
+fn pin_value_range() {
+    assert_parses!(Rule::pin_range, "[10..17]");
+    assert_parses!(Rule::pin_value, "[10..17]");
+}
+
+// ═══════════════════════════════════════════════
+// Pin-bus macro
+// ═══════════════════════════════════════════════
+
+#[test]
+fn pin_bus_call_basic() {
+    assert_parses!(Rule::pin_bus_call, "pin_bus!(PA, 10, 8)");
+    assert_parses!(Rule::pin_bus_call, "pin_bus!(PB, 26, 16)");
+}
+
+// ═══════════════════════════════════════════════
+// Generic parameters & arguments
+// ═══════════════════════════════════════════════
+
+#[test]
+fn generic_params_simple() {
+    assert_parses!(Rule::generic_params, "<pkg: Package>");
+    assert_parses!(Rule::generic_params, "<C: Farads>");
+    assert_parses!(Rule::generic_params, "<R: Ohms, pkg: Package>");
+}
+
+#[test]
+fn generic_params_with_defaults() {
+    assert_parses!(Rule::generic_params, "<pkg: Package = LQFP48>");
+    assert_parses!(
+        Rule::generic_params,
+        "<C: Farads, V: Voltage = 10V, pkg: Package = C0402>"
+    );
+    assert_parses!(Rule::generic_params, "<R: Ohms, P: Package = R0402>");
+}
+
+#[test]
+fn generic_params_impl_constraint() {
+    assert_parses!(Rule::generic_params, "<P: impl Capacitor>");
+    assert_parses!(
+        Rule::generic_params,
+        "<P: impl Capacitor + Polarized>"
+    );
+}
+
+#[test]
+fn generic_args_basic() {
+    assert_parses!(Rule::generic_args, "<C: 100nF>");
+    assert_parses!(Rule::generic_args, "<C: 100nF, V: 10V, pkg: C0402>");
+    assert_parses!(Rule::generic_args, "<R: 10k, pkg: R0402>");
+    assert_parses!(Rule::generic_args, "<pkg: LQFP64>");
+    assert_parses!(Rule::generic_args, "<R: 22R>");
+    assert_parses!(Rule::generic_args, "<C: 10uF, V: 6.3V>");
+}
+
+// ═══════════════════════════════════════════════
+// Type expressions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn type_expr_simple() {
+    assert_parses!(Rule::type_expr, "Net");
+    assert_parses!(Rule::type_expr, "Pin");
+    assert_parses!(Rule::type_expr, "Package");
+    assert_parses!(Rule::type_expr, "BypassCap");
+}
+
+#[test]
+fn type_expr_with_generics() {
+    assert_parses!(Rule::type_expr, "MLCC<C: 100nF, V: 10V, pkg: C0402>");
+    assert_parses!(Rule::type_expr, "Resistor<R: 10k, pkg: R0402>");
+    assert_parses!(Rule::type_expr, "Tantalum<C: 10uF, V: 6.3V>");
+    assert_parses!(Rule::type_expr, "STM32F103<pkg: LQFP64>");
+    assert_parses!(Rule::type_expr, "SmallCap<C: 4.7nF>");
+    assert_parses!(Rule::type_expr, "SeriesRes<R: 22R>");
+}
+
+#[test]
+fn type_expr_scoped_with_generics() {
+    assert_parses!(Rule::type_expr, "stm32::STM32F103<pkg: LQFP64>");
+}
+
+// ═══════════════════════════════════════════════
+// Attributes
+// ═══════════════════════════════════════════════
+
+#[test]
+fn attribute_allow() {
+    assert_parses!(Rule::attribute, "#[allow(unconnected_pin)]");
+    assert_parses!(Rule::attribute, "#[allow(voltage_derating)]");
+}
+
+#[test]
+fn attribute_designator() {
+    assert_parses!(Rule::attribute, r#"#[designator("U1")]"#);
+    assert_parses!(Rule::attribute, r#"#[designator("C1")]"#);
+}
+
+#[test]
+fn attribute_no_args() {
+    assert_parses!(Rule::attribute, "#[some_attr]");
+}
+
+// ═══════════════════════════════════════════════
+// Trait definitions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn trait_basic_pins() {
+    assert_parses!(
+        Rule::trait_def,
+        "trait TwoTerminal {
+            pins {
+                A: Pin
+                B: Pin
+            }
+        }"
+    );
+}
+
+#[test]
+fn trait_with_parent() {
+    assert_parses!(
+        Rule::trait_def,
+        "trait Capacitor: TwoTerminal {
+            spec {
+                capacitance: Farads
+                voltage_rating: Voltage
+            }
+        }"
+    );
+}
+
+#[test]
+fn trait_with_designator_prefix() {
+    assert_parses!(
+        Rule::trait_def,
+        r#"trait Capacitor: TwoTerminal {
+            designator_prefix: "C"
+            spec {
+                capacitance: Farads
+                voltage_rating: Voltage
+            }
+        }"#
+    );
+}
+
+#[test]
+fn trait_with_spec_boolean() {
+    assert_parses!(
+        Rule::trait_def,
+        "trait Polarized: TwoTerminal {
+            spec { polarity: true }
+        }"
+    );
+}
+
+#[test]
+fn trait_with_rule_blocks() {
+    assert_parses!(
+        Rule::trait_def,
+        r#"trait Capacitor: TwoTerminal {
+            spec {
+                capacitance: Farads
+                voltage_rating: Voltage
+            }
+            rule voltage_derating(level: Warning) {
+                assert net_voltage(self.A, self.B) <= self.spec.voltage_rating * 0.8
+                message: "Capacitor voltage exceeds 80% derating: {net_voltage(self.A, self.B)}V > {self.spec.voltage_rating * 0.8}V"
+            }
+            rule voltage_exceed(level: Error) {
+                assert net_voltage(self.A, self.B) <= self.spec.voltage_rating
+                message: "Capacitor voltage {net_voltage(self.A, self.B)}V exceeds voltage_rating {self.spec.voltage_rating}V"
+            }
+        }"#
+    );
+}
+
+#[test]
+fn trait_connector() {
+    assert_parses!(
+        Rule::trait_def,
+        r#"trait Connector {
+            designator_prefix: "J"
+        }"#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Device definitions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn device_simple_passive() {
+    assert_parses!(
+        Rule::device_def,
+        "device MLCC<C: Farads, V: Voltage = 10V, pkg: Package = C0402>: impl Capacitor {
+            package: pkg
+            pins { A: 1, B: 2 }
+            spec {
+                capacitance: C
+                voltage_rating: V
+            }
+        }"
+    );
+}
+
+#[test]
+fn device_multi_trait() {
+    assert_parses!(
+        Rule::device_def,
+        "device Electrolytic<C: Farads, V: Voltage>: impl Capacitor + Polarized {
+            package: RADIAL_D5
+            pins { A: 1, B: 2 }
+            spec {
+                capacitance: C
+                voltage_rating: V
+            }
+        }"
+    );
+}
+
+#[test]
+fn device_with_rule_override() {
+    assert_parses!(
+        Rule::device_def,
+        r#"device Electrolytic<C: Farads, V: Voltage>: impl Capacitor + Polarized {
+            package: RADIAL_D5
+            pins { A: 1, B: 2 }
+            spec { capacitance: C, voltage_rating: V }
+            rule voltage_derating(level: Warning) {
+                assert net_voltage(self.A, self.B) <= self.spec.voltage_rating * 0.6
+                message: "Electrolytic capacitor voltage exceeds 60% derating: {net_voltage(self.A, self.B)}V > {self.spec.voltage_rating * 0.6}V"
+            }
+        }"#
+    );
+}
+
+#[test]
+fn device_multiple_pins_blocks() {
+    assert_parses!(
+        Rule::device_def,
+        "device STM32F103<pkg: Package = LQFP48> {
+            package: pkg
+            pins[LQFP48] {
+                VDD_CORE: 1
+                VDD_IO: 24
+                GND: [8, 23, 35, 47]
+                pin_bus!(PA, 10, 8)
+                pin_bus!(PB, 18, 8)
+                USB_DM: 20
+                USB_DP: 21
+            }
+            pins[LQFP64] {
+                VDD_CORE: 1
+                VDD_IO: 24
+                GND: [8, 23, 35, 47]
+                pin_bus!(PA, 10, 16)
+                pin_bus!(PB, 26, 16)
+                USB_DM: 34
+                USB_DP: 35
+            }
+        }"
+    );
+}
+
+#[test]
+fn device_no_generics_no_impl() {
+    assert_parses!(
+        Rule::device_def,
+        "device SimplePart {
+            package: QFN16
+            pins {
+                VDD: 1
+                GND: 2
+            }
+        }"
+    );
+}
+
+#[test]
+fn device_resistor() {
+    assert_parses!(
+        Rule::device_def,
+        "device Resistor<R: Ohms, pkg: Package = R0402>: impl Resistor {
+            package: pkg
+            pins { A: 1, B: 2 }
+            spec { resistance: R }
+        }"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Part definitions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn part_with_avl() {
+    assert_parses!(
+        Rule::part_def,
+        r#"part mlcc_100nF_0402: MLCC<C: 100nF, V: 10V, pkg: C0402> {
+            primary { mfr: "Samsung", mpn: "CL05B104KO5NNNC" }
+            alt { mfr: "Murata", mpn: "GRM155R61C104KA88D" }
+            alt { mfr: "Yageo", mpn: "CC0402KRX5R9BB104" }
+        }"#
+    );
+}
+
+#[test]
+fn part_resistor() {
+    assert_parses!(
+        Rule::part_def,
+        r#"part res_10k_0402: Resistor<R: 10k, pkg: R0402> {
+            primary { mfr: "Yageo", mpn: "RC0402FR-0710KL" }
+            alt { mfr: "ROHM", mpn: "MCR01MZPF1002" }
+            alt { mfr: "Walsin", mpn: "WR04X1002FTL" }
+        }"#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Type aliases
+// ═══════════════════════════════════════════════
+
+#[test]
+fn type_alias_no_params() {
+    assert_parses!(
+        Rule::type_def,
+        "type BypassCap = MLCC<C: 100nF, V: 10V, pkg: C0402>"
+    );
+    assert_parses!(
+        Rule::type_def,
+        "type BulkCap = Tantalum<C: 10uF, V: 6.3V>"
+    );
+    assert_parses!(
+        Rule::type_def,
+        "type PullupRes = Resistor<R: 10k, pkg: R0402>"
+    );
+}
+
+#[test]
+fn type_alias_with_params() {
+    assert_parses!(
+        Rule::type_def,
+        "type SmallCap<C: Farads> = MLCC<C: C, V: 10V, pkg: C0402>"
+    );
+    assert_parses!(
+        Rule::type_def,
+        "type PowerRes<R: Ohms> = Resistor<R: R, pkg: R2512>"
+    );
+    assert_parses!(
+        Rule::type_def,
+        "type SeriesRes<R: Ohms, P: Package = R0402> = Resistor<R: R, pkg: P>"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Function definitions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn fn_simple_decoupling() {
+    assert_parses!(
+        Rule::fn_def,
+        "fn decoupling<P: impl Capacitor>(
+            vdd: Net,
+            gnd: Net,
+            cap: P
+        ) {
+            inst c: cap
+            net vdd: c.A
+            net gnd: c.B
+        }"
+    );
+}
+
+#[test]
+fn fn_value_generics_with_defaults() {
+    assert_parses!(
+        Rule::fn_def,
+        "fn decoupling_val<C: Capacitance = 100nF, pkg: Package = C0402>(
+            vdd: Net,
+            gnd: Net
+        ) {
+            inst c: MLCC<C: C, pkg: pkg>
+            net vdd: c.A
+            net gnd: c.B
+        }"
+    );
+}
+
+#[test]
+fn fn_multi_trait_bound() {
+    assert_parses!(
+        Rule::fn_def,
+        "fn bulk_cap<P: impl Capacitor + Polarized>(
+            vdd: Net,
+            gnd: Net,
+            cap: P
+        ) {
+            inst c: cap
+            net vdd: c.A
+            net gnd: c.B
+        }"
+    );
+}
+
+#[test]
+fn fn_voltage_divider() {
+    assert_parses!(
+        Rule::fn_def,
+        "fn voltage_divider<R1: Ohms, R2: Ohms>(
+            vin: Net,
+            vout: Net,
+            gnd: Net
+        ) {
+            inst r_top: Resistor<R: R1>
+            inst r_bot: Resistor<R: R2>
+            net vin: r_top.A
+            net vout: r_top.B, r_bot.A
+            net gnd: r_bot.B
+        }"
+    );
+}
+
+#[test]
+fn fn_no_generics() {
+    assert_parses!(
+        Rule::fn_def,
+        "fn usb_termination(dm: Net, dp: Net, gnd: Net) {
+            inst r_dm: SeriesRes<R: 22R>
+            inst r_dp: SeriesRes<R: 22R>
+            net dm: r_dm.A
+            net dp: r_dp.A
+            net gnd: r_dm.B, r_dp.B
+        }"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Module definitions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn module_with_items() {
+    assert_parses!(
+        Rule::module_def,
+        "module passives {
+            pub type BypassCap = MLCC<C: 100nF, V: 10V, pkg: C0402>
+            pub type PullupRes = Resistor<R: 10k, pkg: R0402>
+            pub type SmallCap<C: Farads> = MLCC<C: C, V: 10V, pkg: C0402>
+        }"
+    );
+}
+
+#[test]
+fn module_with_parts() {
+    assert_parses!(
+        Rule::module_def,
+        r#"module passives {
+            pub part res_10k_0402: Resistor<R: 10k, pkg: R0402> {
+                primary { mfr: "Yageo", mpn: "RC0402FR-0710KL" }
+            }
+            pub part mlcc_100nF_0402: MLCC<C: 100nF, pkg: C0402> {
+                primary { mfr: "Samsung", mpn: "CL05B104KO5NNNC" }
+            }
+        }"#
+    );
+}
+
+#[test]
+fn module_with_device() {
+    assert_parses!(
+        Rule::module_def,
+        "module stm32 {
+            pub device STM32F103<pkg: Package = LQFP48> {
+                package: pkg
+                pins {
+                    VDD: 1
+                    GND: 2
+                }
+            }
+        }"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Design definitions
+// ═══════════════════════════════════════════════
+
+#[test]
+fn design_basic() {
+    assert_parses!(
+        Rule::design_def,
+        "design MainBoard {
+            inst mcu: STM32F103<pkg: LQFP64>
+            inst c_bypass: BypassCap
+        }"
+    );
+}
+
+#[test]
+fn design_with_calls() {
+    assert_parses!(
+        Rule::design_def,
+        "design MainBoard {
+            inst mcu: STM32F103<pkg: LQFP64>
+            decoupling(vdd: mcu.VDD_IO, gnd: GND, cap: mlcc_100nF_0402)
+        }"
+    );
+}
+
+#[test]
+fn design_with_scoped_call() {
+    assert_parses!(
+        Rule::design_def,
+        "design MainBoard {
+            inst mcu: STM32F103<pkg: LQFP64>
+            power::ldo(vin: VIN, vout: VCC_3V3, gnd: GND)
+        }"
+    );
+}
+
+#[test]
+fn design_with_attributes() {
+    assert_parses!(
+        Rule::design_def,
+        r#"design MainBoard {
+            #[designator("U1")]
+            inst mcu: STM32F103<pkg: LQFP64>
+            #[allow(unconnected_pin)]
+            inst c_usb: mlcc_100nF_0402
+            #[designator("C1")]
+            inst c_bulk: BulkCap
+        }"#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Use declarations
+// ═══════════════════════════════════════════════
+
+#[test]
+fn use_single_import() {
+    assert_parses!(Rule::use_decl, "use power::decoupling");
+    assert_parses!(Rule::use_decl, "use stm32::STM32F103");
+}
+
+#[test]
+fn use_group_import() {
+    assert_parses!(
+        Rule::use_decl,
+        "use passives::{res_10k_0402, mlcc_100nF_0402}"
+    );
+    assert_parses!(Rule::use_decl, "use passives::{BypassCap, SmallCap}");
+}
+
+// ═══════════════════════════════════════════════
+// Mod declarations
+// ═══════════════════════════════════════════════
+
+#[test]
+fn mod_decl_basic() {
+    assert_parses!(Rule::mod_decl, "mod common");
+}
+
+// ═══════════════════════════════════════════════
+// Statements
+// ═══════════════════════════════════════════════
+
+#[test]
+fn inst_stmt_simple() {
+    assert_parses!(Rule::inst_stmt, "inst c: cap");
+    assert_parses!(Rule::inst_stmt, "inst c_bypass: BypassCap");
+    assert_parses!(Rule::inst_stmt, "inst r_pull: PullupRes");
+    assert_parses!(Rule::inst_stmt, "inst c_filter: SmallCap<C: 4.7nF>");
+    assert_parses!(Rule::inst_stmt, "inst mcu: STM32F103<pkg: LQFP64>");
+}
+
+#[test]
+fn inst_stmt_inline_part() {
+    assert_parses!(
+        Rule::inst_stmt,
+        r#"inst r_sense: Resistor<R: 100m, pkg: R2512> {
+            primary { mfr: "Vishay", mpn: "WSL2512R1000FEA" }
+            alt { mfr: "Bourns", mpn: "CSS2512FT0R100" }
+        }"#
+    );
+}
+
+#[test]
+fn net_stmt_single() {
+    assert_parses!(Rule::net_stmt, "net vdd: c.A");
+    assert_parses!(Rule::net_stmt, "net gnd: c.B");
+}
+
+#[test]
+fn net_stmt_multiple_endpoints() {
+    assert_parses!(Rule::net_stmt, "net vout: r_top.B, r_bot.A");
+    assert_parses!(Rule::net_stmt, "net gnd: r_dm.B, r_dp.B");
+}
+
+#[test]
+fn net_stmt_ident_target_and_endpoints() {
+    assert_parses!(Rule::net_stmt, "net GND: c.B");
+}
+
+#[test]
+fn call_stmt_basic() {
+    assert_parses!(
+        Rule::call_stmt,
+        "decoupling(vdd: mcu.VDD_IO, gnd: GND, cap: mlcc_100nF_0402)"
+    );
+}
+
+#[test]
+fn call_stmt_scoped() {
+    assert_parses!(
+        Rule::call_stmt,
+        "power::ldo(vin: VIN, vout: VCC_3V3, gnd: GND)"
+    );
+}
+
+#[test]
+fn call_stmt_with_generic_overrides() {
+    assert_parses!(
+        Rule::call_stmt,
+        "voltage_divider(vin: V_REF, vout: ADC_IN, gnd: GND, R1: 10k, R2: 4.7k)"
+    );
+}
+
+#[test]
+fn call_stmt_with_type_arg() {
+    assert_parses!(
+        Rule::call_stmt,
+        "decoupling(vdd: mcu.VDD_ANA, gnd: GND, cap: Tantalum<C: 10uF, V: 6.3V>)"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Expression parsing (rule bodies)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn expr_comparison() {
+    assert_parses!(
+        Rule::expr,
+        "net_voltage(self.A, self.B) <= self.spec.voltage_rating * 0.8"
+    );
+}
+
+#[test]
+fn expr_multiplication() {
+    assert_parses!(Rule::expr, "self.spec.voltage_rating * 0.6");
+}
+
+#[test]
+fn expr_fn_call() {
+    assert_parses!(Rule::expr, "net_voltage(self.A, self.B)");
+}
+
+#[test]
+fn expr_dot_path() {
+    assert_parses!(Rule::expr, "self.spec.voltage_rating");
+    assert_parses!(Rule::expr, "self.A");
+    assert_parses!(Rule::expr, "mcu.VDD_IO");
+}
+
+// ═══════════════════════════════════════════════
+// Rule blocks
+// ═══════════════════════════════════════════════
+
+#[test]
+fn rule_block_warning() {
+    assert_parses!(
+        Rule::rule_block,
+        r#"rule voltage_derating(level: Warning) {
+            assert net_voltage(self.A, self.B) <= self.spec.voltage_rating * 0.8
+            message: "Capacitor voltage exceeds 80% derating: {net_voltage(self.A, self.B)}V > {self.spec.voltage_rating * 0.8}V"
+        }"#
+    );
+}
+
+#[test]
+fn rule_block_error() {
+    assert_parses!(
+        Rule::rule_block,
+        r#"rule voltage_exceed(level: Error) {
+            assert net_voltage(self.A, self.B) <= self.spec.voltage_rating
+            message: "Capacitor voltage {net_voltage(self.A, self.B)}V exceeds voltage_rating {self.spec.voltage_rating}V"
+        }"#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Interpolated strings
+// ═══════════════════════════════════════════════
+
+#[test]
+fn interpolated_string_basic() {
+    assert_parses!(
+        Rule::interpolated_string,
+        r#""Capacitor voltage {v}V exceeds {max}V""#
+    );
+}
+
+#[test]
+fn interpolated_string_with_expr() {
+    assert_parses!(
+        Rule::interpolated_string,
+        r#""value: {self.spec.voltage_rating * 0.8}V""#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Pins block
+// ═══════════════════════════════════════════════
+
+#[test]
+fn pins_block_unqualified() {
+    assert_parses!(
+        Rule::pins_block,
+        "pins {
+            A: Pin
+            B: Pin
+        }"
+    );
+}
+
+#[test]
+fn pins_block_with_values() {
+    assert_parses!(Rule::pins_block, "pins { A: 1, B: 2 }");
+}
+
+#[test]
+fn pins_block_qualified() {
+    assert_parses!(
+        Rule::pins_block,
+        "pins[LQFP48] {
+            VDD_CORE: 1
+            GND: [8, 23, 35, 47]
+            pin_bus!(PA, 10, 8)
+            USB_DM: 20
+        }"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Spec block
+// ═══════════════════════════════════════════════
+
+#[test]
+fn spec_block_types() {
+    assert_parses!(
+        Rule::spec_block,
+        "spec {
+            capacitance: Farads
+            voltage_rating: Voltage
+        }"
+    );
+}
+
+#[test]
+fn spec_block_values() {
+    assert_parses!(
+        Rule::spec_block,
+        "spec {
+            capacitance: C
+            voltage_rating: V
+        }"
+    );
+}
+
+#[test]
+fn spec_block_comma_separated() {
+    assert_parses!(Rule::spec_block, "spec { capacitance: C, voltage_rating: V }");
+}
+
+#[test]
+fn spec_block_boolean() {
+    assert_parses!(Rule::spec_block, "spec { polarity: true }");
+}
+
+// ═══════════════════════════════════════════════
+// AVL entries
+// ═══════════════════════════════════════════════
+
+#[test]
+fn avl_entry_primary() {
+    assert_parses!(
+        Rule::avl_entry,
+        r#"primary { mfr: "Samsung", mpn: "CL05B104KO5NNNC" }"#
+    );
+}
+
+#[test]
+fn avl_entry_alt() {
+    assert_parses!(
+        Rule::avl_entry,
+        r#"alt { mfr: "Murata", mpn: "GRM155R61C104KA88D" }"#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// Package declaration
+// ═══════════════════════════════════════════════
+
+#[test]
+fn package_decl_ident() {
+    assert_parses!(Rule::package_decl, "package: pkg");
+    assert_parses!(Rule::package_decl, "package: RADIAL_D5");
+    assert_parses!(Rule::package_decl, "package: QFN16");
+}
+
+// ═══════════════════════════════════════════════
+// Designator prefix
+// ═══════════════════════════════════════════════
+
+#[test]
+fn designator_prefix_test() {
+    assert_parses!(Rule::designator_prefix, r#"designator_prefix: "C""#);
+    assert_parses!(Rule::designator_prefix, r#"designator_prefix: "R""#);
+    assert_parses!(Rule::designator_prefix, r#"designator_prefix: "U""#);
+    assert_parses!(Rule::designator_prefix, r#"designator_prefix: "J""#);
+    assert_parses!(Rule::designator_prefix, r#"designator_prefix: "L""#);
+}
+
+// ═══════════════════════════════════════════════
+// Impl clause
+// ═══════════════════════════════════════════════
+
+#[test]
+fn impl_clause_single() {
+    assert_parses!(Rule::impl_clause, ": impl Capacitor");
+}
+
+#[test]
+fn impl_clause_multi() {
+    assert_parses!(Rule::impl_clause, ": impl Capacitor + Polarized");
+}
+
+// ═══════════════════════════════════════════════
+// Full file parsing
+// ═══════════════════════════════════════════════
+
+#[test]
+fn file_empty() {
+    assert_parses!(Rule::file, "");
+}
+
+#[test]
+fn file_with_comments() {
+    assert_parses!(
+        Rule::file,
+        "// This is a comment
+        // Another comment
+        trait TwoTerminal {
+            pins {
+                A: Pin
+                B: Pin
+            }
+        }"
+    );
+}
+
+#[test]
+fn file_use_and_design() {
+    assert_parses!(
+        Rule::file,
+        "use power::decoupling
+        use passives::{res_10k_0402, mlcc_100nF_0402}
+        use stm32::STM32F103
+
+        design MainBoard {
+            inst mcu: STM32F103<pkg: LQFP64>
+            decoupling(vdd: mcu.VDD_IO, gnd: GND, cap: mlcc_100nF_0402)
+            decoupling(vdd: mcu.VDD_ANA, gnd: GND, cap: mlcc_100nF_0402)
+            power::ldo(vin: VIN, vout: VCC_3V3, gnd: GND)
+        }"
+    );
+}
+
+#[test]
+fn file_mod_declarations() {
+    assert_parses!(
+        Rule::file,
+        "pub mod stm32f1
+        pub mod stm32f4
+        mod common"
+    );
+}
+
+#[test]
+fn file_trait_device_part() {
+    assert_parses!(
+        Rule::file,
+        r#"trait TwoTerminal {
+            pins {
+                A: Pin
+                B: Pin
+            }
+        }
+
+        trait Capacitor: TwoTerminal {
+            designator_prefix: "C"
+            spec {
+                capacitance: Farads
+                voltage_rating: Voltage
+            }
+        }
+
+        device MLCC<C: Farads, V: Voltage = 10V, pkg: Package = C0402>: impl Capacitor {
+            package: pkg
+            pins { A: 1, B: 2 }
+            spec {
+                capacitance: C
+                voltage_rating: V
+            }
+        }
+
+        type BypassCap = MLCC<C: 100nF, V: 10V, pkg: C0402>
+
+        part mlcc_100nF_0402: MLCC<C: 100nF, V: 10V, pkg: C0402> {
+            primary { mfr: "Samsung", mpn: "CL05B104KO5NNNC" }
+            alt { mfr: "Murata", mpn: "GRM155R61C104KA88D" }
+        }
+
+        fn decoupling<P: impl Capacitor>(
+            vdd: Net,
+            gnd: Net,
+            cap: P
+        ) {
+            inst c: cap
+            net vdd: c.A
+            net gnd: c.B
+        }
+
+        design MainBoard {
+            inst mcu: STM32F103<pkg: LQFP64>
+            #[designator("C1")]
+            inst c_bulk: BypassCap
+            decoupling(vdd: mcu.VDD_IO, gnd: GND, cap: mlcc_100nF_0402)
+        }"#
+    );
+}
+
+#[test]
+fn file_module_with_nested_items() {
+    assert_parses!(
+        Rule::file,
+        r#"module power {
+            pub fn decoupling<P: impl Capacitor>(vdd: Net, gnd: Net, cap: P) {
+                inst c: cap
+                net vdd: c.A
+                net gnd: c.B
+            }
+        }
+
+        module passives {
+            pub type BypassCap = MLCC<C: 100nF, V: 10V, pkg: C0402>
+            pub part mlcc_100nF_0402: MLCC<C: 100nF, pkg: C0402> {
+                primary { mfr: "Samsung", mpn: "CL05B104KO5NNNC" }
+            }
+        }"#
+    );
+}
+
+#[test]
+fn file_design_with_all_stmt_types() {
+    assert_parses!(
+        Rule::file,
+        r#"design MainBoard {
+            #[designator("U1")]
+            inst mcu: STM32F103<pkg: LQFP64>
+            #[allow(unconnected_pin)]
+            inst c_bypass: BypassCap
+            inst r_sense: Resistor<R: 100m, pkg: R2512> {
+                primary { mfr: "Vishay", mpn: "WSL2512R1000FEA" }
+            }
+            net VDD: mcu.VDD_IO
+            net GND: mcu.GND, c_bypass.B
+            decoupling(vdd: mcu.VDD_IO, gnd: GND, cap: mlcc_100nF_0402)
+            power::ldo(vin: VIN, vout: VCC_3V3, gnd: GND)
+            voltage_divider(vin: V_REF, vout: ADC_IN, gnd: GND, R1: 10k, R2: 4.7k)
+        }"#
+    );
+}
+
+// ═══════════════════════════════════════════════
+// parses_to! tests for structural verification
+// ═══════════════════════════════════════════════
+
+#[test]
+fn parses_to_ident() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "foo",
+        rule: Rule::ident,
+        tokens: [
+            ident(0, 3)
+        ]
+    };
+}
+
+#[test]
+fn parses_to_eng_number_with_suffix() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "100nF",
+        rule: Rule::eng_number,
+        tokens: [
+            eng_number(0, 5)
+        ]
+    };
+}
+
+#[test]
+fn parses_to_eng_number_plain() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "48",
+        rule: Rule::eng_number,
+        tokens: [
+            eng_number(0, 2)
+        ]
+    };
+}
+
+#[test]
+fn parses_to_string_literal() {
+    // string_literal is atomic, so string_inner is NOT a child token
+    parses_to! {
+        parser: CohdlParser,
+        input: r#""hello""#,
+        rule: Rule::string_literal,
+        tokens: [
+            string_literal(0, 7)
+        ]
+    };
+}
+
+#[test]
+fn parses_to_boolean_true() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "true",
+        rule: Rule::boolean,
+        tokens: [
+            boolean(0, 4)
+        ]
+    };
+}
+
+#[test]
+fn parses_to_pin_list() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "[1, 2, 3]",
+        rule: Rule::pin_list,
+        tokens: [
+            pin_list(0, 9, [
+                integer(1, 2),
+                integer(4, 5),
+                integer(7, 8)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_pin_range() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "[10..17]",
+        rule: Rule::pin_range,
+        tokens: [
+            pin_range(0, 8, [
+                integer(1, 3),
+                integer(5, 7)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_pin_bus_call() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "pin_bus!(PA, 10, 8)",
+        rule: Rule::pin_bus_call,
+        tokens: [
+            pin_bus_call(0, 19, [
+                ident(9, 11),
+                integer(13, 15),
+                integer(17, 18)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_scoped_path() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "power::decoupling",
+        rule: Rule::scoped_path,
+        tokens: [
+            scoped_path(0, 17, [
+                ident(0, 5),
+                ident(7, 17)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_generic_arg() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "C: 100nF",
+        rule: Rule::generic_arg,
+        tokens: [
+            generic_arg(0, 8, [
+                ident(0, 1),
+                value_expr(3, 8, [
+                    expr(3, 8, [
+                        comparison_expr(3, 8, [
+                            additive_expr(3, 8, [
+                                multiplicative_expr(3, 8, [
+                                    unary_expr(3, 8, [
+                                        atom_expr(3, 8, [
+                                            eng_number(3, 8)
+                                        ])
+                                    ])
+                                ])
+                            ])
+                        ])
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_use_group() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "{BypassCap, SmallCap}",
+        rule: Rule::use_group,
+        tokens: [
+            use_group(0, 21, [
+                ident(1, 10),
+                ident(12, 20)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_use_decl_scoped() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "use power::decoupling",
+        rule: Rule::use_decl,
+        tokens: [
+            use_decl(0, 21, [
+                use_path(4, 21, [
+                    ident(4, 9),
+                    ident(11, 21)
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_use_decl_group() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "use passives::{BypassCap, SmallCap}",
+        rule: Rule::use_decl,
+        tokens: [
+            use_decl(0, 35, [
+                use_path(4, 35, [
+                    ident(4, 12),
+                    use_group(14, 35, [
+                        ident(15, 24),
+                        ident(26, 34)
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_attribute_allow() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "#[allow(unconnected_pin)]",
+        rule: Rule::attribute,
+        tokens: [
+            attribute(0, 25, [
+                attribute_inner(2, 24, [
+                    ident(2, 7),
+                    attribute_args(8, 23, [
+                        ident(8, 23)
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_attribute_designator() {
+    // string_literal is atomic so no children
+    parses_to! {
+        parser: CohdlParser,
+        input: r#"#[designator("U1")]"#,
+        rule: Rule::attribute,
+        tokens: [
+            attribute(0, 19, [
+                attribute_inner(2, 18, [
+                    ident(2, 12),
+                    attribute_args(13, 17, [
+                        string_literal(13, 17)
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_mod_decl() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "mod common",
+        rule: Rule::mod_decl,
+        tokens: [
+            mod_decl(0, 10, [
+                ident(4, 10)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_avl_entry() {
+    // string_literal is atomic
+    parses_to! {
+        parser: CohdlParser,
+        input: r#"primary { mfr: "Samsung", mpn: "CL05" }"#,
+        rule: Rule::avl_entry,
+        tokens: [
+            avl_entry(0, 39, [
+                avl_kind(0, 7),
+                avl_field(10, 24, [
+                    ident(10, 13),
+                    string_literal(15, 24)
+                ]),
+                avl_field(26, 37, [
+                    ident(26, 29),
+                    string_literal(31, 37)
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_designator_prefix() {
+    parses_to! {
+        parser: CohdlParser,
+        input: r#"designator_prefix: "C""#,
+        rule: Rule::designator_prefix,
+        tokens: [
+            designator_prefix(0, 22, [
+                string_literal(19, 22)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_package_decl() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "package: pkg",
+        rule: Rule::package_decl,
+        tokens: [
+            package_decl(0, 12, [
+                ident(9, 12)
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_visibility() {
+    parses_to! {
+        parser: CohdlParser,
+        input: "pub",
+        rule: Rule::visibility,
+        tokens: [
+            visibility(0, 3)
+        ]
+    };
+}
+
+#[test]
+fn parses_to_impl_clause() {
+    parses_to! {
+        parser: CohdlParser,
+        input: ": impl Capacitor",
+        rule: Rule::impl_clause,
+        tokens: [
+            impl_clause(0, 16, [
+                trait_bound(7, 16, [
+                    type_expr(7, 16, [
+                        ident(7, 16)
+                    ])
+                ])
+            ])
+        ]
+    };
+}
+
+#[test]
+fn parses_to_impl_clause_multi() {
+    parses_to! {
+        parser: CohdlParser,
+        input: ": impl Capacitor + Polarized",
+        rule: Rule::impl_clause,
+        tokens: [
+            impl_clause(0, 28, [
+                trait_bound(7, 28, [
+                    type_expr(7, 17, [
+                        ident(7, 16)
+                    ]),
+                    type_expr(19, 28, [
+                        ident(19, 28)
+                    ])
+                ])
+            ])
+        ]
+    };
+}


### PR DESCRIPTION
## Summary
This PR introduces a complete PEG grammar specification for the CoHDL hardware description language and a comprehensive test suite to validate parser functionality across all language constructs.

## Key Changes

- **Added `grammar.pest`**: A complete PEG grammar defining the CoHDL language syntax, including:
  - Identifiers, scoped paths, and literals (engineering notation, integers, strings, booleans)
  - Pin specifications (single values, lists, ranges, and `pin_bus!` macro calls)
  - Generic parameters and arguments with constraints and defaults
  - Type expressions with optional generic arguments
  - Attributes (`#[allow(...)]`, `#[designator(...)]`, etc.)
  - Trait definitions with pins, specs, rules, and designator prefixes
  - Device definitions with package-qualified pin blocks and trait implementations
  - Part definitions with AVL (Approved Vendor List) entries
  - Type aliases with optional generic parameters
  - Function definitions with trait bounds and generic constraints
  - Module definitions for organizing components
  - Design definitions with instantiation, net connections, and function calls
  - Use declarations and module declarations
  - Expression hierarchy for rule assertions (comparison, arithmetic, function calls, dot paths)
  - Rule blocks with assert statements and interpolated string messages

- **Added `tests.rs`**: Extensive test coverage (~1,500 lines) validating:
  - Individual rule parsing (identifiers, literals, pin values, generics, types, attributes)
  - Complex constructs (traits, devices, parts, functions, modules, designs)
  - Statement types (instantiation, net connections, function calls)
  - Expression parsing and operator precedence
  - Full file parsing with multiple top-level items
  - Structural verification using `parses_to!` macro for token tree validation

- **Updated `lib.rs`**: Integrated pest parser derivation with the grammar file

- **Updated `Cargo.toml`**: Added pest and pest_derive dependencies (workspace-managed versions)

## Implementation Details

- The grammar uses pest 2.7 with atomic rules for literals to prevent unnecessary token tree expansion
- Comprehensive whitespace and comment handling via implicit WHITESPACE and COMMENT rules
- Expression parsing follows standard precedence: comparison < addition < multiplication < unary < atoms
- Support for both simple and complex generic constraints (trait bounds with `+` composition)
- Package-qualified pin blocks allow different pin mappings for different package variants
- Interpolated strings support embedded expressions within `{...}` delimiters

https://claude.ai/code/session_01EfFmYwrdMBQj9E5EMdnM4R