### PR TITLE
Implement built-in DRC rule engine on ConnectivityIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,10 @@ version = "0.1.0"
 [[package]]
 name = "cohdl-drc"
 version = "0.1.0"
+dependencies = [
+ "cohdl-sema",
+ "cohdl-syntax",
+]
 
 [[package]]
 name = "cohdl-lsp"

--- a/crates/cohdl-drc/Cargo.toml
+++ b/crates/cohdl-drc/Cargo.toml
@@ -3,3 +3,7 @@ name = "cohdl-drc"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+
+[dependencies]
+cohdl-sema = { path = "../cohdl-sema" }
+cohdl-syntax = { path = "../cohdl-syntax" }

--- a/crates/cohdl-drc/src/lib.rs
+++ b/crates/cohdl-drc/src/lib.rs
@@ -1,1 +1,104 @@
+//! Built-in DRC (Design Rule Check) engine operating on [`ConnectivityIR`].
+//!
+//! Each rule is a struct implementing the [`DrcRule`] trait. [`DrcRunner`]
+//! collects all built-in rules and executes them, returning a flat list of
+//! [`DrcDiagnostic`]s. Diagnostics whose `rule_id` matches an
+//! `#[allow(rule_name)]` annotation on the owning instance are suppressed.
 
+pub mod rules;
+
+use cohdl_sema::connectivity::ConnectivityIR;
+use cohdl_syntax::ast::Span;
+
+// ── Diagnostic types ─────────────────────────────────────────────────────────
+
+/// Severity level for a DRC diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticLevel {
+    Error,
+    Warning,
+}
+
+/// A single diagnostic emitted by a DRC rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrcDiagnostic {
+    /// Machine-readable rule identifier (e.g. `"E001"`, `"W002"`).
+    pub rule_id: String,
+    /// Severity.
+    pub level: DiagnosticLevel,
+    /// Source span associated with the offending construct.
+    pub span: Span,
+    /// Hierarchical instance path (empty for net-level diagnostics).
+    pub instance_path: String,
+    /// Human-readable message.
+    pub message: String,
+}
+
+// ── DrcRule trait ─────────────────────────────────────────────────────────────
+
+/// A single, stateless DRC rule.
+pub trait DrcRule {
+    /// Execute the rule against the given IR, returning zero or more diagnostics.
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic>;
+}
+
+// ── DrcRunner ────────────────────────────────────────────────────────────────
+
+/// Collects all built-in rules and runs them, optionally filtering out
+/// suppressed diagnostics.
+pub struct DrcRunner {
+    rules: Vec<Box<dyn DrcRule>>,
+    /// Set of `(instance_path, rule_id)` pairs that should be suppressed.
+    suppressed: Vec<(String, String)>,
+}
+
+impl DrcRunner {
+    /// Create a runner pre-loaded with every built-in rule.
+    pub fn new() -> Self {
+        Self {
+            rules: vec![
+                Box::new(rules::VoltageExceed),
+                Box::new(rules::PolarityMismatch),
+                Box::new(rules::SpecNotSatisfied),
+                Box::new(rules::TraitNotImpl),
+                Box::new(rules::MissingSpecField),
+                Box::new(rules::UnconnectedPin),
+                Box::new(rules::FloatingNet),
+                Box::new(rules::SingleDriver),
+                Box::new(rules::MultiDriver),
+            ],
+            suppressed: Vec::new(),
+        }
+    }
+
+    /// Register an `#[allow(rule_name)]` suppression for a given instance path.
+    pub fn allow(&mut self, instance_path: &str, rule_id: &str) {
+        self.suppressed
+            .push((instance_path.to_string(), rule_id.to_string()));
+    }
+
+    /// Run every rule and return the (possibly filtered) diagnostics.
+    pub fn run(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let mut diags: Vec<DrcDiagnostic> = Vec::new();
+        for rule in &self.rules {
+            diags.extend(rule.check(ir));
+        }
+        // Filter out suppressed diagnostics.
+        diags.retain(|d| {
+            !self
+                .suppressed
+                .iter()
+                .any(|(path, id)| d.instance_path == *path && d.rule_id == *id)
+        });
+        diags
+    }
+}
+
+impl Default for DrcRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/cohdl-drc/src/rules.rs
+++ b/crates/cohdl-drc/src/rules.rs
@@ -181,9 +181,7 @@ impl DrcRule for PolarityMismatch {
 fn is_polarized(inst: &Instance) -> bool {
     inst.generic_substitutions
         .iter()
-        .any(|(k, v)| {
-            (k == "impl_traits" || k == "impl_trait") && v.contains("Polarized")
-        })
+        .any(|(k, v)| (k == "impl_traits" || k == "impl_trait") && v.contains("Polarized"))
 }
 
 // ── E003: spec_not_satisfied ─────────────────────────────────────────────────
@@ -196,8 +194,11 @@ impl DrcRule for SpecNotSatisfied {
         let mut out = Vec::new();
         for inst in &ir.instances {
             if let Some(required) = inst.generic_substitutions.get("required_specs") {
-                let required_fields: Vec<&str> =
-                    required.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                let required_fields: Vec<&str> = required
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .collect();
                 for field in required_fields {
                     if !inst.generic_substitutions.contains_key(field) {
                         out.push(diag(
@@ -227,8 +228,11 @@ impl DrcRule for TraitNotImpl {
         let mut out = Vec::new();
         for inst in &ir.instances {
             if let Some(required) = inst.generic_substitutions.get("required_traits") {
-                let required_traits: Vec<&str> =
-                    required.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                let required_traits: Vec<&str> = required
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .collect();
                 let impl_traits: HashSet<&str> = inst
                     .generic_substitutions
                     .get("impl_traits")
@@ -263,8 +267,11 @@ impl DrcRule for MissingSpecField {
         let mut out = Vec::new();
         for inst in &ir.instances {
             if let Some(expected) = inst.generic_substitutions.get("expected_spec_fields") {
-                let fields: Vec<&str> =
-                    expected.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                let fields: Vec<&str> = expected
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .collect();
                 for field in fields {
                     if !inst.generic_substitutions.contains_key(field) {
                         out.push(diag(
@@ -305,8 +312,11 @@ impl DrcRule for UnconnectedPin {
             // If the instance declares expected pins via generic_substitutions,
             // check each one.
             if let Some(pins_str) = inst.generic_substitutions.get("declared_pins") {
-                let declared: Vec<&str> =
-                    pins_str.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                let declared: Vec<&str> = pins_str
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .collect();
                 for pin in declared {
                     if !connected.contains(&(inst.id, pin)) {
                         out.push(diag(
@@ -342,7 +352,10 @@ impl DrcRule for FloatingNet {
                     "W002",
                     DiagnosticLevel::Error,
                     "",
-                    format!("net `{}` exists but has no instance pins connected", net.name),
+                    format!(
+                        "net `{}` exists but has no instance pins connected",
+                        net.name
+                    ),
                 ));
             }
         }

--- a/crates/cohdl-drc/src/rules.rs
+++ b/crates/cohdl-drc/src/rules.rs
@@ -1,0 +1,435 @@
+//! Built-in DRC rule implementations.
+//!
+//! Each struct implements [`DrcRule`] and is named after its rule ID in the spec.
+
+use std::collections::{HashMap, HashSet};
+
+use cohdl_sema::connectivity::{ConnectivityIR, Instance, Net};
+use cohdl_sema::typeck::EXTERNAL_INSTANCE;
+use cohdl_syntax::ast::Span;
+
+use crate::{DiagnosticLevel, DrcDiagnostic, DrcRule};
+
+/// Convenience: build a diagnostic.
+fn diag(
+    rule_id: &str,
+    level: DiagnosticLevel,
+    instance_path: &str,
+    message: impl Into<String>,
+) -> DrcDiagnostic {
+    DrcDiagnostic {
+        rule_id: rule_id.to_string(),
+        level,
+        span: Span { start: 0, end: 0 },
+        instance_path: instance_path.to_string(),
+        message: message.into(),
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a map from InstanceId → &Instance for fast lookup.
+fn instance_map(ir: &ConnectivityIR) -> HashMap<cohdl_sema::typeck::InstanceId, &Instance> {
+    ir.instances.iter().map(|i| (i.id, i)).collect()
+}
+
+/// Parse a voltage string like `"3.3V"`, `"5V"`, `"1.8V"` into an f64.
+fn parse_voltage(s: &str) -> Option<f64> {
+    let s = s.trim();
+    let numeric = s.trim_end_matches('V').trim_end_matches('v');
+    numeric.parse::<f64>().ok()
+}
+
+/// Check whether a net name conventionally indicates a GND net.
+fn is_gnd_net(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower == "gnd" || lower == "vss" || lower == "gnd_analog" || lower.starts_with("gnd")
+}
+
+// ── E001: voltage_exceed ─────────────────────────────────────────────────────
+
+/// Instance `voltage_rating` is less than the voltage annotation on the net it
+/// is connected to.
+pub struct VoltageExceed;
+
+impl DrcRule for VoltageExceed {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let imap = instance_map(ir);
+        let mut out = Vec::new();
+
+        for net in &ir.nets {
+            // Determine the net voltage from its name or from a connected
+            // instance that carries a `voltage` generic substitution.
+            let net_voltage = net_voltage_annotation(net, &imap);
+            let net_v = match net_voltage {
+                Some(v) => v,
+                None => continue,
+            };
+
+            for pin in &net.pins {
+                if pin.instance_id == EXTERNAL_INSTANCE {
+                    continue;
+                }
+                if let Some(inst) = imap.get(&pin.instance_id) {
+                    if let Some(rating_str) = inst.generic_substitutions.get("voltage_rating") {
+                        if let Some(rating) = parse_voltage(rating_str) {
+                            if rating < net_v {
+                                out.push(diag(
+                                    "E001",
+                                    DiagnosticLevel::Error,
+                                    &inst.hierarchical_path,
+                                    format!(
+                                        "voltage_rating {}V is less than net `{}` voltage {}V",
+                                        rating, net.name, net_v
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Derive net voltage: look for instances on the net that have a `voltage`
+/// generic substitution, or try to parse the net name (e.g. `"3V3"` → 3.3).
+fn net_voltage_annotation(
+    net: &Net,
+    imap: &HashMap<cohdl_sema::typeck::InstanceId, &Instance>,
+) -> Option<f64> {
+    // First: check for any instance that carries a `voltage` substitution.
+    for pin in &net.pins {
+        if pin.instance_id == EXTERNAL_INSTANCE {
+            continue;
+        }
+        if let Some(inst) = imap.get(&pin.instance_id) {
+            if let Some(v_str) = inst.generic_substitutions.get("voltage") {
+                if let Some(v) = parse_voltage(v_str) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    // Second: try to extract voltage from net name (e.g. "3V3" → 3.3, "5V" → 5.0).
+    parse_net_name_voltage(&net.name)
+}
+
+fn parse_net_name_voltage(name: &str) -> Option<f64> {
+    // "3V3" → 3.3, "5V" → 5.0, "1V8" → 1.8
+    if let Some(pos) = name.find('V') {
+        let before = &name[..pos];
+        let after = &name[pos + 1..];
+        if let Ok(int) = before.parse::<u32>() {
+            if after.is_empty() {
+                return Some(int as f64);
+            }
+            if let Ok(frac) = after.parse::<u32>() {
+                let denom = 10f64.powi(after.len() as i32);
+                return Some(int as f64 + frac as f64 / denom);
+            }
+        }
+    }
+    None
+}
+
+// ── E002: polarity_mismatch ──────────────────────────────────────────────────
+
+/// A device implementing `Polarized` has its anode (`A`) pin connected to a
+/// GND-annotated net.
+pub struct PolarityMismatch;
+
+impl DrcRule for PolarityMismatch {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let imap = instance_map(ir);
+        let mut out = Vec::new();
+
+        for net in &ir.nets {
+            if !is_gnd_net(&net.name) {
+                continue;
+            }
+            for pin in &net.pins {
+                if pin.instance_id == EXTERNAL_INSTANCE {
+                    continue;
+                }
+                if pin.pin != "A" {
+                    continue;
+                }
+                if let Some(inst) = imap.get(&pin.instance_id) {
+                    if is_polarized(inst) {
+                        out.push(diag(
+                            "E002",
+                            DiagnosticLevel::Error,
+                            &inst.hierarchical_path,
+                            format!(
+                                "polarized device `{}` has anode (A) connected to GND net `{}`",
+                                inst.device, net.name
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// A device is "polarized" if its generic substitutions contain
+/// `impl_trait = "Polarized"` or it has an `impl_traits` entry containing
+/// `"Polarized"`.
+fn is_polarized(inst: &Instance) -> bool {
+    inst.generic_substitutions
+        .iter()
+        .any(|(k, v)| {
+            (k == "impl_traits" || k == "impl_trait") && v.contains("Polarized")
+        })
+}
+
+// ── E003: spec_not_satisfied ─────────────────────────────────────────────────
+
+/// A device implementing a trait that requires spec fields is missing one.
+pub struct SpecNotSatisfied;
+
+impl DrcRule for SpecNotSatisfied {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let mut out = Vec::new();
+        for inst in &ir.instances {
+            if let Some(required) = inst.generic_substitutions.get("required_specs") {
+                let required_fields: Vec<&str> =
+                    required.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                for field in required_fields {
+                    if !inst.generic_substitutions.contains_key(field) {
+                        out.push(diag(
+                            "E003",
+                            DiagnosticLevel::Error,
+                            &inst.hierarchical_path,
+                            format!(
+                                "trait spec field `{}` missing on device `{}`",
+                                field, inst.device
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ── E004: trait_not_impl ─────────────────────────────────────────────────────
+
+/// A generic argument doesn't implement the required trait.
+pub struct TraitNotImpl;
+
+impl DrcRule for TraitNotImpl {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let mut out = Vec::new();
+        for inst in &ir.instances {
+            if let Some(required) = inst.generic_substitutions.get("required_traits") {
+                let required_traits: Vec<&str> =
+                    required.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                let impl_traits: HashSet<&str> = inst
+                    .generic_substitutions
+                    .get("impl_traits")
+                    .map(|s| s.split(',').map(|t| t.trim()).collect())
+                    .unwrap_or_default();
+                for t in required_traits {
+                    if !impl_traits.contains(t) {
+                        out.push(diag(
+                            "E004",
+                            DiagnosticLevel::Error,
+                            &inst.hierarchical_path,
+                            format!(
+                                "generic argument on `{}` does not implement required trait `{}`",
+                                inst.device, t
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ── E005: missing_spec_field ─────────────────────────────────────────────────
+
+/// A trait spec field is not provided in the device instantiation.
+pub struct MissingSpecField;
+
+impl DrcRule for MissingSpecField {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let mut out = Vec::new();
+        for inst in &ir.instances {
+            if let Some(expected) = inst.generic_substitutions.get("expected_spec_fields") {
+                let fields: Vec<&str> =
+                    expected.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                for field in fields {
+                    if !inst.generic_substitutions.contains_key(field) {
+                        out.push(diag(
+                            "E005",
+                            DiagnosticLevel::Error,
+                            &inst.hierarchical_path,
+                            format!(
+                                "spec field `{}` not provided in device `{}`",
+                                field, inst.device
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ── W001: unconnected_pin ────────────────────────────────────────────────────
+
+/// A pin on an instance has no net connection.
+pub struct UnconnectedPin;
+
+impl DrcRule for UnconnectedPin {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        // Collect all (instance_id, pin) pairs that appear on any net.
+        let connected: HashSet<(cohdl_sema::typeck::InstanceId, &str)> = ir
+            .nets
+            .iter()
+            .flat_map(|n| n.pins.iter())
+            .filter(|p| p.instance_id != EXTERNAL_INSTANCE)
+            .map(|p| (p.instance_id, p.pin.as_str()))
+            .collect();
+
+        let mut out = Vec::new();
+        for inst in &ir.instances {
+            // If the instance declares expected pins via generic_substitutions,
+            // check each one.
+            if let Some(pins_str) = inst.generic_substitutions.get("declared_pins") {
+                let declared: Vec<&str> =
+                    pins_str.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+                for pin in declared {
+                    if !connected.contains(&(inst.id, pin)) {
+                        out.push(diag(
+                            "W001",
+                            DiagnosticLevel::Warning,
+                            &inst.hierarchical_path,
+                            format!("pin `{}` on `{}` is unconnected", pin, inst.name),
+                        ));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ── W002: floating_net ───────────────────────────────────────────────────────
+
+/// A net exists but has no instance pins connected (only external or none).
+pub struct FloatingNet;
+
+impl DrcRule for FloatingNet {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let mut out = Vec::new();
+        for net in &ir.nets {
+            let instance_pin_count = net
+                .pins
+                .iter()
+                .filter(|p| p.instance_id != EXTERNAL_INSTANCE)
+                .count();
+            if instance_pin_count == 0 {
+                out.push(diag(
+                    "W002",
+                    DiagnosticLevel::Error,
+                    "",
+                    format!("net `{}` exists but has no instance pins connected", net.name),
+                ));
+            }
+        }
+        out
+    }
+}
+
+// ── W003: single_driver ──────────────────────────────────────────────────────
+
+/// A net has exactly one passive-pin connection (likely unfinished wiring).
+pub struct SingleDriver;
+
+impl DrcRule for SingleDriver {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let mut out = Vec::new();
+        for net in &ir.nets {
+            let instance_pins: Vec<_> = net
+                .pins
+                .iter()
+                .filter(|p| p.instance_id != EXTERNAL_INSTANCE)
+                .collect();
+            if instance_pins.len() == 1 {
+                let pin = &instance_pins[0];
+                let imap = instance_map(ir);
+                let inst_path = imap
+                    .get(&pin.instance_id)
+                    .map(|i| i.hierarchical_path.as_str())
+                    .unwrap_or("");
+                out.push(diag(
+                    "W003",
+                    DiagnosticLevel::Warning,
+                    inst_path,
+                    format!(
+                        "net `{}` has only one instance pin connection ({}.{})",
+                        net.name, inst_path, pin.pin
+                    ),
+                ));
+            }
+        }
+        out
+    }
+}
+
+// ── W004: multi_driver ───────────────────────────────────────────────────────
+
+/// A net has multiple output-type pins connected.
+pub struct MultiDriver;
+
+impl DrcRule for MultiDriver {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let imap = instance_map(ir);
+        let mut out = Vec::new();
+        for net in &ir.nets {
+            let mut output_pins = Vec::new();
+            for pin in &net.pins {
+                if pin.instance_id == EXTERNAL_INSTANCE {
+                    continue;
+                }
+                if let Some(inst) = imap.get(&pin.instance_id) {
+                    // Check if this pin is declared as an output via
+                    // `output_pins` generic substitution.
+                    if let Some(outputs) = inst.generic_substitutions.get("output_pins") {
+                        let output_set: HashSet<&str> =
+                            outputs.split(',').map(|s| s.trim()).collect();
+                        if output_set.contains(pin.pin.as_str()) {
+                            output_pins.push((inst, &pin.pin));
+                        }
+                    }
+                }
+            }
+            if output_pins.len() > 1 {
+                let drivers: Vec<String> = output_pins
+                    .iter()
+                    .map(|(inst, pin)| format!("{}.{}", inst.hierarchical_path, pin))
+                    .collect();
+                out.push(diag(
+                    "W004",
+                    DiagnosticLevel::Error,
+                    "",
+                    format!(
+                        "net `{}` has multiple output drivers: {}",
+                        net.name,
+                        drivers.join(", ")
+                    ),
+                ));
+            }
+        }
+        out
+    }
+}

--- a/crates/cohdl-drc/src/tests.rs
+++ b/crates/cohdl-drc/src/tests.rs
@@ -3,8 +3,8 @@
 use cohdl_sema::connectivity::{ConnectivityIR, Instance, Net, PinRef};
 use cohdl_sema::typeck::{InstanceId, EXTERNAL_INSTANCE};
 
-use crate::{DiagnosticLevel, DrcRule, DrcRunner};
 use crate::rules::*;
+use crate::{DiagnosticLevel, DrcRule, DrcRunner};
 
 // ── Fixture helpers ──────────────────────────────────────────────────────────
 
@@ -52,7 +52,12 @@ fn ir(instances: Vec<Instance>, nets: Vec<Net>) -> ConnectivityIR {
 #[test]
 fn e001_triggers_when_rating_below_net_voltage() {
     let design = ir(
-        vec![inst(0, "c1", "MLCC", &[("voltage_rating", "3.3V"), ("voltage", "5V")])],
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[("voltage_rating", "3.3V"), ("voltage", "5V")],
+        )],
         vec![net("5V", vec![pinref(0, "A")])],
     );
     let diags = VoltageExceed.check(&design);
@@ -66,7 +71,12 @@ fn e001_triggers_when_rating_below_net_voltage() {
 #[test]
 fn e001_no_trigger_when_rating_sufficient() {
     let design = ir(
-        vec![inst(0, "c1", "MLCC", &[("voltage_rating", "10V"), ("voltage", "5V")])],
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[("voltage_rating", "10V"), ("voltage", "5V")],
+        )],
         vec![net("5V", vec![pinref(0, "A")])],
     );
     let diags = VoltageExceed.check(&design);
@@ -124,7 +134,12 @@ fn e002_no_trigger_non_polarized() {
 #[test]
 fn e003_triggers_missing_spec() {
     let design = ir(
-        vec![inst(0, "c1", "MLCC", &[("required_specs", "capacitance,voltage_rating")])],
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[("required_specs", "capacitance,voltage_rating")],
+        )],
         vec![],
     );
     let diags = SpecNotSatisfied.check(&design);
@@ -139,10 +154,7 @@ fn e003_no_trigger_when_specs_present() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("required_specs", "capacitance"),
-                ("capacitance", "100nF"),
-            ],
+            &[("required_specs", "capacitance"), ("capacitance", "100nF")],
         )],
         vec![],
     );
@@ -155,7 +167,15 @@ fn e003_no_trigger_when_specs_present() {
 #[test]
 fn e004_triggers_missing_trait() {
     let design = ir(
-        vec![inst(0, "x", "Generic", &[("required_traits", "Capacitor"), ("impl_traits", "Resistor")])],
+        vec![inst(
+            0,
+            "x",
+            "Generic",
+            &[
+                ("required_traits", "Capacitor"),
+                ("impl_traits", "Resistor"),
+            ],
+        )],
         vec![],
     );
     let diags = TraitNotImpl.check(&design);
@@ -167,7 +187,15 @@ fn e004_triggers_missing_trait() {
 #[test]
 fn e004_no_trigger_when_trait_present() {
     let design = ir(
-        vec![inst(0, "x", "Generic", &[("required_traits", "Capacitor"), ("impl_traits", "Capacitor")])],
+        vec![inst(
+            0,
+            "x",
+            "Generic",
+            &[
+                ("required_traits", "Capacitor"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
         vec![],
     );
     let diags = TraitNotImpl.check(&design);
@@ -179,7 +207,12 @@ fn e004_no_trigger_when_trait_present() {
 #[test]
 fn e005_triggers_missing_field() {
     let design = ir(
-        vec![inst(0, "c1", "MLCC", &[("expected_spec_fields", "capacitance,tolerance")])],
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[("expected_spec_fields", "capacitance,tolerance")],
+        )],
         vec![],
     );
     let diags = MissingSpecField.check(&design);
@@ -237,10 +270,7 @@ fn w001_no_trigger_all_connected() {
 
 #[test]
 fn w002_triggers_on_floating_net() {
-    let design = ir(
-        vec![],
-        vec![net("ORPHAN", vec![ext_pin("ORPHAN")])],
-    );
+    let design = ir(vec![], vec![net("ORPHAN", vec![ext_pin("ORPHAN")])]);
     let diags = FloatingNet.check(&design);
     assert_eq!(diags.len(), 1);
     assert_eq!(diags[0].rule_id, "W002");
@@ -274,10 +304,7 @@ fn w003_triggers_single_instance_pin() {
 #[test]
 fn w003_no_trigger_two_instance_pins() {
     let design = ir(
-        vec![
-            inst(0, "c1", "MLCC", &[]),
-            inst(1, "r1", "RES", &[]),
-        ],
+        vec![inst(0, "c1", "MLCC", &[]), inst(1, "r1", "RES", &[])],
         vec![net("N1", vec![pinref(0, "A"), pinref(1, "A")])],
     );
     let diags = SingleDriver.check(&design);
@@ -337,7 +364,9 @@ fn runner_allow_suppresses_diagnostic() {
     let mut runner = DrcRunner::new();
     runner.allow("Board::d1", "E002");
     let diags = runner.run(&design);
-    assert!(!diags.iter().any(|d| d.rule_id == "E002" && d.instance_path == "Board::d1"));
+    assert!(!diags
+        .iter()
+        .any(|d| d.rule_id == "E002" && d.instance_path == "Board::d1"));
 }
 
 #[test]

--- a/crates/cohdl-drc/src/tests.rs
+++ b/crates/cohdl-drc/src/tests.rs
@@ -1,0 +1,349 @@
+//! Unit tests for DRC rules using synthetic ConnectivityIR fixtures.
+
+use cohdl_sema::connectivity::{ConnectivityIR, Instance, Net, PinRef};
+use cohdl_sema::typeck::{InstanceId, EXTERNAL_INSTANCE};
+
+use crate::{DiagnosticLevel, DrcRule, DrcRunner};
+use crate::rules::*;
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+fn inst(id: u32, name: &str, device: &str, subs: &[(&str, &str)]) -> Instance {
+    Instance {
+        id: InstanceId(id),
+        name: name.to_string(),
+        hierarchical_path: format!("Board::{}", name),
+        device: device.to_string(),
+        mpn: None,
+        generic_substitutions: subs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    }
+}
+
+fn pinref(id: u32, pin: &str) -> PinRef {
+    PinRef {
+        instance_id: InstanceId(id),
+        pin: pin.to_string(),
+    }
+}
+
+fn ext_pin(pin: &str) -> PinRef {
+    PinRef {
+        instance_id: EXTERNAL_INSTANCE,
+        pin: pin.to_string(),
+    }
+}
+
+fn net(name: &str, pins: Vec<PinRef>) -> Net {
+    Net {
+        name: name.to_string(),
+        pins,
+    }
+}
+
+fn ir(instances: Vec<Instance>, nets: Vec<Net>) -> ConnectivityIR {
+    ConnectivityIR { instances, nets }
+}
+
+// ── E001: voltage_exceed ─────────────────────────────────────────────────────
+
+#[test]
+fn e001_triggers_when_rating_below_net_voltage() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("voltage_rating", "3.3V"), ("voltage", "5V")])],
+        vec![net("5V", vec![pinref(0, "A")])],
+    );
+    let diags = VoltageExceed.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "E001");
+    assert_eq!(diags[0].level, DiagnosticLevel::Error);
+    assert!(diags[0].message.contains("voltage_rating"));
+    assert_eq!(diags[0].instance_path, "Board::c1");
+}
+
+#[test]
+fn e001_no_trigger_when_rating_sufficient() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("voltage_rating", "10V"), ("voltage", "5V")])],
+        vec![net("5V", vec![pinref(0, "A")])],
+    );
+    let diags = VoltageExceed.check(&design);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn e001_detects_voltage_from_net_name() {
+    // Net name "3V3" implies 3.3 V; a 3 V rated part should fail.
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("voltage_rating", "3V")])],
+        vec![net("3V3", vec![pinref(0, "A")])],
+    );
+    let diags = VoltageExceed.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "E001");
+}
+
+// ── E002: polarity_mismatch ──────────────────────────────────────────────────
+
+#[test]
+fn e002_triggers_anode_on_gnd() {
+    let design = ir(
+        vec![inst(0, "d1", "LED", &[("impl_traits", "Polarized")])],
+        vec![net("GND", vec![ext_pin("GND"), pinref(0, "A")])],
+    );
+    let diags = PolarityMismatch.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "E002");
+    assert!(diags[0].message.contains("anode"));
+}
+
+#[test]
+fn e002_no_trigger_cathode_on_gnd() {
+    let design = ir(
+        vec![inst(0, "d1", "LED", &[("impl_traits", "Polarized")])],
+        vec![net("GND", vec![ext_pin("GND"), pinref(0, "K")])],
+    );
+    let diags = PolarityMismatch.check(&design);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn e002_no_trigger_non_polarized() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[])],
+        vec![net("GND", vec![ext_pin("GND"), pinref(0, "A")])],
+    );
+    let diags = PolarityMismatch.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── E003: spec_not_satisfied ─────────────────────────────────────────────────
+
+#[test]
+fn e003_triggers_missing_spec() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("required_specs", "capacitance,voltage_rating")])],
+        vec![],
+    );
+    let diags = SpecNotSatisfied.check(&design);
+    assert_eq!(diags.len(), 2);
+    assert!(diags.iter().all(|d| d.rule_id == "E003"));
+}
+
+#[test]
+fn e003_no_trigger_when_specs_present() {
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("required_specs", "capacitance"),
+                ("capacitance", "100nF"),
+            ],
+        )],
+        vec![],
+    );
+    let diags = SpecNotSatisfied.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── E004: trait_not_impl ─────────────────────────────────────────────────────
+
+#[test]
+fn e004_triggers_missing_trait() {
+    let design = ir(
+        vec![inst(0, "x", "Generic", &[("required_traits", "Capacitor"), ("impl_traits", "Resistor")])],
+        vec![],
+    );
+    let diags = TraitNotImpl.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "E004");
+    assert!(diags[0].message.contains("Capacitor"));
+}
+
+#[test]
+fn e004_no_trigger_when_trait_present() {
+    let design = ir(
+        vec![inst(0, "x", "Generic", &[("required_traits", "Capacitor"), ("impl_traits", "Capacitor")])],
+        vec![],
+    );
+    let diags = TraitNotImpl.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── E005: missing_spec_field ─────────────────────────────────────────────────
+
+#[test]
+fn e005_triggers_missing_field() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("expected_spec_fields", "capacitance,tolerance")])],
+        vec![],
+    );
+    let diags = MissingSpecField.check(&design);
+    assert_eq!(diags.len(), 2);
+    assert!(diags.iter().all(|d| d.rule_id == "E005"));
+}
+
+#[test]
+fn e005_no_trigger_when_fields_present() {
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("expected_spec_fields", "capacitance"),
+                ("capacitance", "100nF"),
+            ],
+        )],
+        vec![],
+    );
+    let diags = MissingSpecField.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── W001: unconnected_pin ────────────────────────────────────────────────────
+
+#[test]
+fn w001_triggers_on_unconnected_pin() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("declared_pins", "A,B")])],
+        vec![net("VDD", vec![pinref(0, "A")])],
+    );
+    let diags = UnconnectedPin.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "W001");
+    assert_eq!(diags[0].level, DiagnosticLevel::Warning);
+    assert!(diags[0].message.contains("B"));
+}
+
+#[test]
+fn w001_no_trigger_all_connected() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("declared_pins", "A,B")])],
+        vec![
+            net("VDD", vec![pinref(0, "A")]),
+            net("GND", vec![pinref(0, "B")]),
+        ],
+    );
+    let diags = UnconnectedPin.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── W002: floating_net ───────────────────────────────────────────────────────
+
+#[test]
+fn w002_triggers_on_floating_net() {
+    let design = ir(
+        vec![],
+        vec![net("ORPHAN", vec![ext_pin("ORPHAN")])],
+    );
+    let diags = FloatingNet.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "W002");
+    assert_eq!(diags[0].level, DiagnosticLevel::Error);
+}
+
+#[test]
+fn w002_no_trigger_with_instance_pin() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[])],
+        vec![net("VDD", vec![ext_pin("VDD"), pinref(0, "A")])],
+    );
+    let diags = FloatingNet.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── W003: single_driver ──────────────────────────────────────────────────────
+
+#[test]
+fn w003_triggers_single_instance_pin() {
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[])],
+        vec![net("LONELY", vec![pinref(0, "A")])],
+    );
+    let diags = SingleDriver.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "W003");
+    assert_eq!(diags[0].level, DiagnosticLevel::Warning);
+}
+
+#[test]
+fn w003_no_trigger_two_instance_pins() {
+    let design = ir(
+        vec![
+            inst(0, "c1", "MLCC", &[]),
+            inst(1, "r1", "RES", &[]),
+        ],
+        vec![net("N1", vec![pinref(0, "A"), pinref(1, "A")])],
+    );
+    let diags = SingleDriver.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── W004: multi_driver ───────────────────────────────────────────────────────
+
+#[test]
+fn w004_triggers_multiple_outputs() {
+    let design = ir(
+        vec![
+            inst(0, "u1", "BUF", &[("output_pins", "Y")]),
+            inst(1, "u2", "BUF", &[("output_pins", "Y")]),
+        ],
+        vec![net("BUS", vec![pinref(0, "Y"), pinref(1, "Y")])],
+    );
+    let diags = MultiDriver.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "W004");
+    assert_eq!(diags[0].level, DiagnosticLevel::Error);
+    assert!(diags[0].message.contains("multiple output"));
+}
+
+#[test]
+fn w004_no_trigger_single_output() {
+    let design = ir(
+        vec![
+            inst(0, "u1", "BUF", &[("output_pins", "Y")]),
+            inst(1, "r1", "RES", &[]),
+        ],
+        vec![net("SIG", vec![pinref(0, "Y"), pinref(1, "A")])],
+    );
+    let diags = MultiDriver.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── DrcRunner integration ────────────────────────────────────────────────────
+
+#[test]
+fn runner_collects_diagnostics_from_all_rules() {
+    let design = ir(
+        vec![inst(0, "d1", "LED", &[("impl_traits", "Polarized")])],
+        vec![net("GND", vec![ext_pin("GND"), pinref(0, "A")])],
+    );
+    let runner = DrcRunner::new();
+    let diags = runner.run(&design);
+    assert!(diags.iter().any(|d| d.rule_id == "E002"));
+}
+
+#[test]
+fn runner_allow_suppresses_diagnostic() {
+    let design = ir(
+        vec![inst(0, "d1", "LED", &[("impl_traits", "Polarized")])],
+        vec![net("GND", vec![ext_pin("GND"), pinref(0, "A")])],
+    );
+    let mut runner = DrcRunner::new();
+    runner.allow("Board::d1", "E002");
+    let diags = runner.run(&design);
+    assert!(!diags.iter().any(|d| d.rule_id == "E002" && d.instance_path == "Board::d1"));
+}
+
+#[test]
+fn runner_empty_design_no_diagnostics() {
+    let design = ir(vec![], vec![]);
+    let runner = DrcRunner::new();
+    let diags = runner.run(&design);
+    assert!(diags.is_empty());
+}


### PR DESCRIPTION
Add 9 DRC rules (E001-E005, W001-W004) each as a struct implementing
the DrcRule trait. DrcRunner collects all rules and supports
#[allow(rule_name)] suppression via instance path. Includes 23 unit
tests covering positive/negative cases for every rule plus runner
integration.

https://claude.ai/code/session_013xuAg2mtMxEPMoagr51g99