### PR TITLE
Add user-defined DRC rules with expression IR and device override

### DIFF
--- a/crates/cohdl-drc/src/lib.rs
+++ b/crates/cohdl-drc/src/lib.rs
@@ -6,6 +6,7 @@
 //! `#[allow(rule_name)]` annotation on the owning instance are suppressed.
 
 pub mod rules;
+pub mod user_rules;
 
 use cohdl_sema::connectivity::ConnectivityIR;
 use cohdl_syntax::ast::Span;
@@ -69,6 +70,13 @@ impl DrcRunner {
             ],
             suppressed: Vec::new(),
         }
+    }
+
+    /// Add a [`UserDefinedRuleSet`] containing user-defined rules from `trait`
+    /// and `device` definitions.  User-defined diagnostics appear alongside
+    /// built-in ones in the output.
+    pub fn add_user_rules(&mut self, rule_set: user_rules::UserDefinedRuleSet) {
+        self.rules.push(Box::new(rule_set));
     }
 
     /// Register an `#[allow(rule_name)]` suppression for a given instance path.

--- a/crates/cohdl-drc/src/tests.rs
+++ b/crates/cohdl-drc/src/tests.rs
@@ -4,6 +4,9 @@ use cohdl_sema::connectivity::{ConnectivityIR, Instance, Net, PinRef};
 use cohdl_sema::typeck::{InstanceId, EXTERNAL_INSTANCE};
 
 use crate::rules::*;
+use crate::user_rules::{
+    RuleAppliesTo, RuleBinOp, RuleExpr, UserDefinedRule, UserDefinedRuleSet,
+};
 use crate::{DiagnosticLevel, DrcRule, DrcRunner};
 
 // ── Fixture helpers ──────────────────────────────────────────────────────────
@@ -375,4 +378,420 @@ fn runner_empty_design_no_diagnostics() {
     let runner = DrcRunner::new();
     let diags = runner.run(&design);
     assert!(diags.is_empty());
+}
+
+// ── User-defined rules: expression evaluation ──────────────────────────────
+
+#[test]
+fn user_rule_spec_field_float_literal() {
+    // Simple assertion: self.spec.voltage_rating >= 5.0
+    let rule = UserDefinedRule {
+        name: "min_voltage".into(),
+        level: DiagnosticLevel::Warning,
+        assertion: RuleExpr::Binary {
+            op: RuleBinOp::Ge,
+            lhs: Box::new(RuleExpr::SpecField("voltage_rating".into())),
+            rhs: Box::new(RuleExpr::Float(5.0)),
+        },
+        message_template: "voltage_rating {voltage_rating} is below 5V".into(),
+        applies_to: RuleAppliesTo::Trait("Capacitor".into()),
+    };
+
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(rule);
+
+    // Instance with rating 3.3V — should trigger.
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "3.3V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![],
+    );
+    let diags = rules.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "min_voltage");
+    assert_eq!(diags[0].level, DiagnosticLevel::Warning);
+    assert!(diags[0].message.contains("3.3V"));
+}
+
+#[test]
+fn user_rule_no_trigger_when_assertion_holds() {
+    let rule = UserDefinedRule {
+        name: "min_voltage".into(),
+        level: DiagnosticLevel::Warning,
+        assertion: RuleExpr::Binary {
+            op: RuleBinOp::Ge,
+            lhs: Box::new(RuleExpr::SpecField("voltage_rating".into())),
+            rhs: Box::new(RuleExpr::Float(5.0)),
+        },
+        message_template: "too low".into(),
+        applies_to: RuleAppliesTo::Trait("Capacitor".into()),
+    };
+
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(rule);
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![],
+    );
+    let diags = rules.check(&design);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn user_rule_does_not_apply_to_unrelated_device() {
+    let rule = UserDefinedRule {
+        name: "cap_check".into(),
+        level: DiagnosticLevel::Warning,
+        assertion: RuleExpr::Float(0.0), // Would always be falsy, but shouldn't apply.
+        message_template: "should not fire".into(),
+        applies_to: RuleAppliesTo::Trait("Capacitor".into()),
+    };
+
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(rule);
+
+    // Instance is a Resistor, not a Capacitor.
+    let design = ir(
+        vec![inst(0, "r1", "RES", &[("impl_traits", "Resistor")])],
+        vec![],
+    );
+    let diags = rules.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── User-defined rules: voltage_derating from Capacitor trait ──────────────
+
+/// Build the `voltage_derating` rule as it would appear in a `Capacitor` trait:
+///
+/// ```hdl
+/// rule voltage_derating(level: Warning) {
+///     assert self.spec.voltage_rating * 0.8 >= net_voltage(self.A, self.B)
+///     message: "net voltage {net_voltage}V exceeds 80% derating of {voltage_rating}"
+/// }
+/// ```
+fn capacitor_voltage_derating_rule() -> UserDefinedRule {
+    UserDefinedRule {
+        name: "voltage_derating".into(),
+        level: DiagnosticLevel::Warning,
+        assertion: RuleExpr::Binary {
+            op: RuleBinOp::Ge,
+            lhs: Box::new(RuleExpr::Binary {
+                op: RuleBinOp::Mul,
+                lhs: Box::new(RuleExpr::SpecField("voltage_rating".into())),
+                rhs: Box::new(RuleExpr::Float(0.8)),
+            }),
+            rhs: Box::new(RuleExpr::NetVoltage {
+                pin_a: "A".into(),
+                pin_b: "B".into(),
+            }),
+        },
+        message_template:
+            "net voltage {net_voltage}V exceeds 80% derating of {voltage_rating}".into(),
+        applies_to: RuleAppliesTo::Trait("Capacitor".into()),
+    }
+}
+
+#[test]
+fn voltage_derating_triggers_when_close_to_rating() {
+    // Capacitor rated 10V on a 9V net — 9 > 10*0.8 = 8, so should trigger.
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
+    );
+
+    let diags = rules.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "voltage_derating");
+    assert_eq!(diags[0].level, DiagnosticLevel::Warning);
+    assert_eq!(diags[0].instance_path, "Board::c1");
+    assert!(diags[0].message.contains("9"));
+    assert!(diags[0].message.contains("derating"));
+}
+
+#[test]
+fn voltage_derating_no_trigger_within_margin() {
+    // Capacitor rated 10V on a 5V net — 5 <= 10*0.8 = 8, so should NOT trigger.
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("5V", vec![pinref(0, "A"), ext_pin("5V")])],
+    );
+
+    let diags = rules.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── User-defined rules: device override of trait rule ──────────────────────
+
+/// Build a stricter `voltage_derating` rule for an `Electrolytic` device:
+/// 50% derating instead of 80%.
+///
+/// ```hdl
+/// device Electrolytic: impl Capacitor {
+///     rule voltage_derating(level: Warning) {
+///         assert self.spec.voltage_rating * 0.5 >= net_voltage(self.A, self.B)
+///         message: "net voltage {net_voltage}V exceeds 50% derating of {voltage_rating}"
+///     }
+/// }
+/// ```
+fn electrolytic_voltage_derating_override() -> UserDefinedRule {
+    UserDefinedRule {
+        name: "voltage_derating".into(),
+        level: DiagnosticLevel::Warning,
+        assertion: RuleExpr::Binary {
+            op: RuleBinOp::Ge,
+            lhs: Box::new(RuleExpr::Binary {
+                op: RuleBinOp::Mul,
+                lhs: Box::new(RuleExpr::SpecField("voltage_rating".into())),
+                rhs: Box::new(RuleExpr::Float(0.5)),
+            }),
+            rhs: Box::new(RuleExpr::NetVoltage {
+                pin_a: "A".into(),
+                pin_b: "B".into(),
+            }),
+        },
+        message_template:
+            "net voltage {net_voltage}V exceeds 50% derating of {voltage_rating}".into(),
+        applies_to: RuleAppliesTo::Device("Electrolytic".into()),
+    }
+}
+
+#[test]
+fn device_override_uses_stricter_rule() {
+    // Both the trait rule (80%) and the device rule (50%) are registered.
+    // For an Electrolytic instance, the device rule should override the trait rule.
+    // Rated 10V on a 6V net:
+    //   - 80% rule: 10*0.8 = 8 >= 6 → passes
+    //   - 50% rule: 10*0.5 = 5 >= 6 → FAILS → should trigger
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+    rules.add(electrolytic_voltage_derating_override());
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "Electrolytic",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("6V", vec![pinref(0, "A"), ext_pin("6V")])],
+    );
+
+    let diags = rules.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "voltage_derating");
+    // Confirm it's the device's 50% message, not the trait's 80%.
+    assert!(diags[0].message.contains("50%"));
+}
+
+#[test]
+fn trait_rule_still_applies_to_non_overriding_device() {
+    // An MLCC (non-electrolytic) should still use the trait's 80% derating.
+    // Rated 10V on a 9V net: 10*0.8 = 8 < 9 → triggers.
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+    rules.add(electrolytic_voltage_derating_override());
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
+    );
+
+    let diags = rules.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("80%"));
+}
+
+#[test]
+fn device_override_no_trigger_within_stricter_margin() {
+    // Electrolytic rated 10V on a 4V net: 10*0.5 = 5 >= 4 → passes.
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+    rules.add(electrolytic_voltage_derating_override());
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "Electrolytic",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("4V", vec![pinref(0, "A"), ext_pin("4V")])],
+    );
+
+    let diags = rules.check(&design);
+    assert!(diags.is_empty());
+}
+
+// ── Integration: user-defined rules in DrcRunner ───────────────────────────
+
+#[test]
+fn runner_includes_user_defined_diagnostics() {
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+
+    let mut runner = DrcRunner::new();
+    runner.add_user_rules(rules);
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
+    );
+
+    let diags = runner.run(&design);
+    assert!(diags.iter().any(|d| d.rule_id == "voltage_derating"));
+}
+
+#[test]
+fn runner_suppresses_user_defined_diagnostic() {
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+
+    let mut runner = DrcRunner::new();
+    runner.add_user_rules(rules);
+    runner.allow("Board::c1", "voltage_derating");
+
+    let design = ir(
+        vec![inst(
+            0,
+            "c1",
+            "MLCC",
+            &[
+                ("voltage_rating", "10V"),
+                ("impl_traits", "Capacitor"),
+            ],
+        )],
+        vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
+    );
+
+    let diags = runner.run(&design);
+    assert!(!diags.iter().any(|d| d.rule_id == "voltage_derating"));
+}
+
+// ── Expression IR: arithmetic operations ───────────────────────────────────
+
+#[test]
+fn user_rule_mul_and_comparison() {
+    // Assert: self.spec.capacitance * 1000.0 >= 100.0
+    // i.e. capacitance must be at least 100mF = 0.1F when multiplied by 1000.
+    // 100nF = 1e-7 → 1e-7 * 1000 = 1e-4 < 100 → should trigger.
+    let rule = UserDefinedRule {
+        name: "min_cap".into(),
+        level: DiagnosticLevel::Error,
+        assertion: RuleExpr::Binary {
+            op: RuleBinOp::Ge,
+            lhs: Box::new(RuleExpr::Binary {
+                op: RuleBinOp::Mul,
+                lhs: Box::new(RuleExpr::SpecField("capacitance".into())),
+                rhs: Box::new(RuleExpr::Float(1000.0)),
+            }),
+            rhs: Box::new(RuleExpr::Float(100.0)),
+        },
+        message_template: "capacitance too low".into(),
+        applies_to: RuleAppliesTo::Device("MLCC".into()),
+    };
+
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(rule);
+
+    let design = ir(
+        vec![inst(0, "c1", "MLCC", &[("capacitance", "100nF")])],
+        vec![],
+    );
+
+    let diags = rules.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "min_cap");
+    assert_eq!(diags[0].level, DiagnosticLevel::Error);
+}
+
+#[test]
+fn user_rule_net_voltage_with_instance_voltage_annotation() {
+    // Instance carries voltage=5V, so net_voltage should resolve to 5.0.
+    let mut rules = UserDefinedRuleSet::new();
+    rules.add(capacitor_voltage_derating_rule());
+
+    // c1 rated 6V; voltage source instance on same net annotated 5V.
+    // 6*0.8 = 4.8 < 5 → triggers.
+    let design = ir(
+        vec![
+            inst(
+                0,
+                "c1",
+                "MLCC",
+                &[
+                    ("voltage_rating", "6V"),
+                    ("impl_traits", "Capacitor"),
+                ],
+            ),
+            inst(1, "vreg", "LDO", &[("voltage", "5V")]),
+        ],
+        vec![net(
+            "VDD",
+            vec![pinref(0, "A"), pinref(1, "OUT")],
+        )],
+    );
+
+    let diags = rules.check(&design);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].rule_id, "voltage_derating");
 }

--- a/crates/cohdl-drc/src/tests.rs
+++ b/crates/cohdl-drc/src/tests.rs
@@ -4,9 +4,7 @@ use cohdl_sema::connectivity::{ConnectivityIR, Instance, Net, PinRef};
 use cohdl_sema::typeck::{InstanceId, EXTERNAL_INSTANCE};
 
 use crate::rules::*;
-use crate::user_rules::{
-    RuleAppliesTo, RuleBinOp, RuleExpr, UserDefinedRule, UserDefinedRuleSet,
-};
+use crate::user_rules::{RuleAppliesTo, RuleBinOp, RuleExpr, UserDefinedRule, UserDefinedRuleSet};
 use crate::{DiagnosticLevel, DrcRule, DrcRunner};
 
 // ── Fixture helpers ──────────────────────────────────────────────────────────
@@ -406,10 +404,7 @@ fn user_rule_spec_field_float_literal() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "3.3V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "3.3V"), ("impl_traits", "Capacitor")],
         )],
         vec![],
     );
@@ -442,10 +437,7 @@ fn user_rule_no_trigger_when_assertion_holds() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![],
     );
@@ -501,8 +493,8 @@ fn capacitor_voltage_derating_rule() -> UserDefinedRule {
                 pin_b: "B".into(),
             }),
         },
-        message_template:
-            "net voltage {net_voltage}V exceeds 80% derating of {voltage_rating}".into(),
+        message_template: "net voltage {net_voltage}V exceeds 80% derating of {voltage_rating}"
+            .into(),
         applies_to: RuleAppliesTo::Trait("Capacitor".into()),
     }
 }
@@ -518,10 +510,7 @@ fn voltage_derating_triggers_when_close_to_rating() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
     );
@@ -546,10 +535,7 @@ fn voltage_derating_no_trigger_within_margin() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("5V", vec![pinref(0, "A"), ext_pin("5V")])],
     );
@@ -587,8 +573,8 @@ fn electrolytic_voltage_derating_override() -> UserDefinedRule {
                 pin_b: "B".into(),
             }),
         },
-        message_template:
-            "net voltage {net_voltage}V exceeds 50% derating of {voltage_rating}".into(),
+        message_template: "net voltage {net_voltage}V exceeds 50% derating of {voltage_rating}"
+            .into(),
         applies_to: RuleAppliesTo::Device("Electrolytic".into()),
     }
 }
@@ -609,10 +595,7 @@ fn device_override_uses_stricter_rule() {
             0,
             "c1",
             "Electrolytic",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("6V", vec![pinref(0, "A"), ext_pin("6V")])],
     );
@@ -637,10 +620,7 @@ fn trait_rule_still_applies_to_non_overriding_device() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
     );
@@ -662,10 +642,7 @@ fn device_override_no_trigger_within_stricter_margin() {
             0,
             "c1",
             "Electrolytic",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("4V", vec![pinref(0, "A"), ext_pin("4V")])],
     );
@@ -689,10 +666,7 @@ fn runner_includes_user_defined_diagnostics() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
     );
@@ -715,10 +689,7 @@ fn runner_suppresses_user_defined_diagnostic() {
             0,
             "c1",
             "MLCC",
-            &[
-                ("voltage_rating", "10V"),
-                ("impl_traits", "Capacitor"),
-            ],
+            &[("voltage_rating", "10V"), ("impl_traits", "Capacitor")],
         )],
         vec![net("9V", vec![pinref(0, "A"), ext_pin("9V")])],
     );
@@ -778,17 +749,11 @@ fn user_rule_net_voltage_with_instance_voltage_annotation() {
                 0,
                 "c1",
                 "MLCC",
-                &[
-                    ("voltage_rating", "6V"),
-                    ("impl_traits", "Capacitor"),
-                ],
+                &[("voltage_rating", "6V"), ("impl_traits", "Capacitor")],
             ),
             inst(1, "vreg", "LDO", &[("voltage", "5V")]),
         ],
-        vec![net(
-            "VDD",
-            vec![pinref(0, "A"), pinref(1, "OUT")],
-        )],
+        vec![net("VDD", vec![pinref(0, "A"), pinref(1, "OUT")])],
     );
 
     let diags = rules.check(&design);

--- a/crates/cohdl-drc/src/user_rules.rs
+++ b/crates/cohdl-drc/src/user_rules.rs
@@ -112,24 +112,22 @@ fn eval(expr: &RuleExpr, ctx: &EvalCtx<'_>) -> Option<Value> {
             let l = eval(lhs, ctx)?;
             let r = eval(rhs, ctx)?;
             match (l, r) {
-                (Value::Float(a), Value::Float(b)) => {
-                    match op {
-                        RuleBinOp::Mul => Some(Value::Float(a * b)),
-                        RuleBinOp::Div => {
-                            if b == 0.0 {
-                                None
-                            } else {
-                                Some(Value::Float(a / b))
-                            }
+                (Value::Float(a), Value::Float(b)) => match op {
+                    RuleBinOp::Mul => Some(Value::Float(a * b)),
+                    RuleBinOp::Div => {
+                        if b == 0.0 {
+                            None
+                        } else {
+                            Some(Value::Float(a / b))
                         }
-                        RuleBinOp::Add => Some(Value::Float(a + b)),
-                        RuleBinOp::Sub => Some(Value::Float(a - b)),
-                        RuleBinOp::Le => Some(Value::Bool(a <= b)),
-                        RuleBinOp::Ge => Some(Value::Bool(a >= b)),
-                        RuleBinOp::Lt => Some(Value::Bool(a < b)),
-                        RuleBinOp::Gt => Some(Value::Bool(a > b)),
                     }
-                }
+                    RuleBinOp::Add => Some(Value::Float(a + b)),
+                    RuleBinOp::Sub => Some(Value::Float(a - b)),
+                    RuleBinOp::Le => Some(Value::Bool(a <= b)),
+                    RuleBinOp::Ge => Some(Value::Bool(a >= b)),
+                    RuleBinOp::Lt => Some(Value::Bool(a < b)),
+                    RuleBinOp::Gt => Some(Value::Bool(a > b)),
+                },
                 // Type mismatch — skip silently.
                 _ => None,
             }
@@ -215,10 +213,7 @@ fn parse_numeric(s: &str) -> Option<f64> {
 
 /// Parse a voltage string like `"3.3V"` or `"5V"` into an f64.
 fn parse_voltage_str(s: &str) -> Option<f64> {
-    let numeric = s
-        .trim()
-        .trim_end_matches('V')
-        .trim_end_matches('v');
+    let numeric = s.trim().trim_end_matches('V').trim_end_matches('v');
     numeric.parse::<f64>().ok()
 }
 
@@ -247,11 +242,7 @@ fn parse_net_name_voltage(name: &str) -> Option<f64> {
 /// Supported placeholders:
 /// - `{field}` — looks up `field` in `generic_substitutions`.
 /// - `{net_voltage}` — uses the pre-computed net voltage (if available).
-fn interpolate_message(
-    template: &str,
-    inst: &Instance,
-    net_voltage_val: Option<f64>,
-) -> String {
+fn interpolate_message(template: &str, inst: &Instance, net_voltage_val: Option<f64>) -> String {
     let mut result = String::with_capacity(template.len());
     let mut chars = template.chars().peekable();
 
@@ -268,12 +259,12 @@ fn interpolate_message(
                 if let Some(v) = net_voltage_val {
                     result.push_str(&format!("{v}"));
                 } else {
-                    result.push_str("?");
+                    result.push('?');
                 }
             } else if let Some(val) = inst.generic_substitutions.get(&name) {
                 result.push_str(val);
             } else {
-                result.push_str("?");
+                result.push('?');
             }
         } else {
             result.push(ch);
@@ -318,11 +309,7 @@ fn rule_matches(rule: &UserDefinedRule, inst: &Instance) -> bool {
         RuleAppliesTo::Trait(trait_name) => inst
             .generic_substitutions
             .get("impl_traits")
-            .map(|traits| {
-                traits
-                    .split(',')
-                    .any(|t| t.trim() == trait_name.as_str())
-            })
+            .map(|traits| traits.split(',').any(|t| t.trim() == trait_name.as_str()))
             .unwrap_or(false),
     }
 }
@@ -383,8 +370,7 @@ impl Default for UserDefinedRuleSet {
 
 impl DrcRule for UserDefinedRuleSet {
     fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
-        let imap: HashMap<InstanceId, &Instance> =
-            ir.instances.iter().map(|i| (i.id, i)).collect();
+        let imap: HashMap<InstanceId, &Instance> = ir.instances.iter().map(|i| (i.id, i)).collect();
 
         let mut out = Vec::new();
 
@@ -406,8 +392,7 @@ impl DrcRule for UserDefinedRuleSet {
                         // Assertion holds — no diagnostic.
                     }
                     Some(Value::Bool(false)) => {
-                        let message =
-                            interpolate_message(&rule.message_template, inst, nv);
+                        let message = interpolate_message(&rule.message_template, inst, nv);
                         out.push(DrcDiagnostic {
                             rule_id: rule.name.clone(),
                             level: rule.level,
@@ -437,10 +422,8 @@ fn compute_net_voltage_for_rule(expr: &RuleExpr, ctx: &EvalCtx<'_>) -> Option<f6
                 None
             }
         }
-        RuleExpr::Binary { lhs, rhs, .. } => {
-            compute_net_voltage_for_rule(lhs, ctx)
-                .or_else(|| compute_net_voltage_for_rule(rhs, ctx))
-        }
+        RuleExpr::Binary { lhs, rhs, .. } => compute_net_voltage_for_rule(lhs, ctx)
+            .or_else(|| compute_net_voltage_for_rule(rhs, ctx)),
         _ => None,
     }
 }

--- a/crates/cohdl-drc/src/user_rules.rs
+++ b/crates/cohdl-drc/src/user_rules.rs
@@ -1,0 +1,446 @@
+//! User-defined DRC rules declared in `trait` and `device` definitions.
+//!
+//! A user-defined rule has the form:
+//!
+//! ```hdl
+//! rule voltage_derating(level: Warning) {
+//!   assert net_voltage(self.A, self.B) <= self.spec.voltage_rating * 0.8
+//!   message: "voltage {voltage}V exceeds 80% derating of {voltage_rating}V"
+//! }
+//! ```
+//!
+//! This module provides:
+//! - [`RuleExpr`]: a simple expression IR for rule assertions.
+//! - [`UserDefinedRule`]: the definition of a single user-defined rule.
+//! - [`UserDefinedRuleSet`]: a collection that handles trait/device rule override.
+//! - Evaluation against [`ConnectivityIR`] at DRC time.
+
+use std::collections::HashMap;
+
+use cohdl_sema::connectivity::{ConnectivityIR, Instance, Net};
+use cohdl_sema::typeck::{InstanceId, EXTERNAL_INSTANCE};
+use cohdl_syntax::ast::Span;
+
+use crate::{DiagnosticLevel, DrcDiagnostic, DrcRule};
+
+// ── Expression IR ────────────────────────────────────────────────────────────
+
+/// A simple expression IR for rule assertion evaluation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuleExpr {
+    /// A float literal (e.g. `0.8`, `3.3`).
+    Float(f64),
+    /// Reference to `self.spec.<field>` — resolved from instance
+    /// `generic_substitutions`.
+    SpecField(String),
+    /// `net_voltage(pin_a, pin_b)` — the voltage on the net(s) connecting the
+    /// given pins of the current instance.
+    NetVoltage { pin_a: String, pin_b: String },
+    /// A binary operation.
+    Binary {
+        op: RuleBinOp,
+        lhs: Box<RuleExpr>,
+        rhs: Box<RuleExpr>,
+    },
+}
+
+/// Binary operators supported in rule expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleBinOp {
+    /// `*`
+    Mul,
+    /// `/`
+    Div,
+    /// `+`
+    Add,
+    /// `-`
+    Sub,
+    /// `<=`
+    Le,
+    /// `>=`
+    Ge,
+    /// `<`
+    Lt,
+    /// `>`
+    Gt,
+}
+
+// ── Evaluation ───────────────────────────────────────────────────────────────
+
+/// Result of evaluating a [`RuleExpr`].
+#[derive(Debug, Clone, Copy)]
+enum Value {
+    Float(f64),
+    Bool(bool),
+}
+
+/// Context needed for expression evaluation.
+struct EvalCtx<'a> {
+    /// The instance being checked.
+    inst: &'a Instance,
+    /// All nets in the design.
+    nets: &'a [Net],
+    /// Map from InstanceId → &Instance.
+    imap: &'a HashMap<InstanceId, &'a Instance>,
+}
+
+/// Evaluate a [`RuleExpr`] in the given context.
+fn eval(expr: &RuleExpr, ctx: &EvalCtx<'_>) -> Option<Value> {
+    match expr {
+        RuleExpr::Float(v) => Some(Value::Float(*v)),
+
+        RuleExpr::SpecField(field) => {
+            let raw = ctx.inst.generic_substitutions.get(field)?;
+            parse_numeric(raw).map(Value::Float)
+        }
+
+        RuleExpr::NetVoltage { pin_a, pin_b } => {
+            let va = pin_net_voltage(ctx.inst.id, pin_a, ctx.nets, ctx.imap);
+            let vb = pin_net_voltage(ctx.inst.id, pin_b, ctx.nets, ctx.imap);
+            // If both pins have voltage annotations, return the absolute
+            // difference.  If only one does, use that (the other is assumed 0,
+            // e.g. GND).  If neither has one, the expression is unevaluable.
+            match (va, vb) {
+                (Some(a), Some(b)) => Some(Value::Float((a - b).abs())),
+                (Some(a), None) => Some(Value::Float(a)),
+                (None, Some(b)) => Some(Value::Float(b)),
+                (None, None) => None,
+            }
+        }
+
+        RuleExpr::Binary { op, lhs, rhs } => {
+            let l = eval(lhs, ctx)?;
+            let r = eval(rhs, ctx)?;
+            match (l, r) {
+                (Value::Float(a), Value::Float(b)) => {
+                    match op {
+                        RuleBinOp::Mul => Some(Value::Float(a * b)),
+                        RuleBinOp::Div => {
+                            if b == 0.0 {
+                                None
+                            } else {
+                                Some(Value::Float(a / b))
+                            }
+                        }
+                        RuleBinOp::Add => Some(Value::Float(a + b)),
+                        RuleBinOp::Sub => Some(Value::Float(a - b)),
+                        RuleBinOp::Le => Some(Value::Bool(a <= b)),
+                        RuleBinOp::Ge => Some(Value::Bool(a >= b)),
+                        RuleBinOp::Lt => Some(Value::Bool(a < b)),
+                        RuleBinOp::Gt => Some(Value::Bool(a > b)),
+                    }
+                }
+                // Type mismatch — skip silently.
+                _ => None,
+            }
+        }
+    }
+}
+
+/// Determine the voltage on the net connected to a specific pin of an instance.
+fn pin_net_voltage(
+    inst_id: InstanceId,
+    pin_name: &str,
+    nets: &[Net],
+    imap: &HashMap<InstanceId, &Instance>,
+) -> Option<f64> {
+    // Find the net containing (inst_id, pin_name).
+    let net = nets.iter().find(|n| {
+        n.pins
+            .iter()
+            .any(|p| p.instance_id == inst_id && p.pin == pin_name)
+    })?;
+
+    // Try to derive voltage from other instances on the net (look for a
+    // `voltage` generic substitution).
+    for pin in &net.pins {
+        if pin.instance_id == EXTERNAL_INSTANCE || pin.instance_id == inst_id {
+            continue;
+        }
+        if let Some(other) = imap.get(&pin.instance_id) {
+            if let Some(v_str) = other.generic_substitutions.get("voltage") {
+                if let Some(v) = parse_voltage_str(v_str) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+
+    // Fall back to net-name heuristics (e.g. "3V3" → 3.3, "5V" → 5.0).
+    parse_net_name_voltage(&net.name)
+}
+
+// ── Numeric helpers ──────────────────────────────────────────────────────────
+
+/// Parse a numeric string that may carry an engineering suffix (e.g. `"3.3V"`,
+/// `"100nF"`, `"10k"`).  Returns the bare numeric value in base units.
+fn parse_numeric(s: &str) -> Option<f64> {
+    let s = s.trim();
+
+    // Try direct float parse first.
+    if let Ok(v) = s.parse::<f64>() {
+        return Some(v);
+    }
+
+    // Strip known suffixes and try again.
+    let stripped = s
+        .trim_end_matches('V')
+        .trim_end_matches('v')
+        .trim_end_matches('F')
+        .trim_end_matches('f')
+        .trim_end_matches('A')
+        .trim_end_matches('a')
+        .trim_end_matches("ohm")
+        .trim_end_matches('R');
+
+    // Handle SI multiplier prefixes on what remains.
+    if stripped.is_empty() {
+        return None;
+    }
+
+    let last = stripped.as_bytes()[stripped.len() - 1];
+    let (num_part, multiplier) = match last {
+        b'p' => (&stripped[..stripped.len() - 1], 1e-12),
+        b'n' => (&stripped[..stripped.len() - 1], 1e-9),
+        b'u' => (&stripped[..stripped.len() - 1], 1e-6),
+        b'm' => (&stripped[..stripped.len() - 1], 1e-3),
+        b'k' | b'K' => (&stripped[..stripped.len() - 1], 1e3),
+        b'M' => (&stripped[..stripped.len() - 1], 1e6),
+        b'G' => (&stripped[..stripped.len() - 1], 1e9),
+        _ => (stripped, 1.0),
+    };
+
+    num_part.parse::<f64>().ok().map(|v| v * multiplier)
+}
+
+/// Parse a voltage string like `"3.3V"` or `"5V"` into an f64.
+fn parse_voltage_str(s: &str) -> Option<f64> {
+    let numeric = s
+        .trim()
+        .trim_end_matches('V')
+        .trim_end_matches('v');
+    numeric.parse::<f64>().ok()
+}
+
+/// Extract voltage from a net name such as `"3V3"` → 3.3, `"5V"` → 5.0.
+fn parse_net_name_voltage(name: &str) -> Option<f64> {
+    if let Some(pos) = name.find('V') {
+        let before = &name[..pos];
+        let after = &name[pos + 1..];
+        if let Ok(int) = before.parse::<u32>() {
+            if after.is_empty() {
+                return Some(int as f64);
+            }
+            if let Ok(frac) = after.parse::<u32>() {
+                let denom = 10f64.powi(after.len() as i32);
+                return Some(int as f64 + frac as f64 / denom);
+            }
+        }
+    }
+    None
+}
+
+// ── Message template interpolation ───────────────────────────────────────────
+
+/// Interpolate `{field}` placeholders in a message template.
+///
+/// Supported placeholders:
+/// - `{field}` — looks up `field` in `generic_substitutions`.
+/// - `{net_voltage}` — uses the pre-computed net voltage (if available).
+fn interpolate_message(
+    template: &str,
+    inst: &Instance,
+    net_voltage_val: Option<f64>,
+) -> String {
+    let mut result = String::with_capacity(template.len());
+    let mut chars = template.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            let mut name = String::new();
+            for c in chars.by_ref() {
+                if c == '}' {
+                    break;
+                }
+                name.push(c);
+            }
+            if name == "net_voltage" {
+                if let Some(v) = net_voltage_val {
+                    result.push_str(&format!("{v}"));
+                } else {
+                    result.push_str("?");
+                }
+            } else if let Some(val) = inst.generic_substitutions.get(&name) {
+                result.push_str(val);
+            } else {
+                result.push_str("?");
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+// ── UserDefinedRule ──────────────────────────────────────────────────────────
+
+/// Describes which instances a user-defined rule applies to.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuleAppliesTo {
+    /// The rule applies to instances of a specific device.
+    Device(String),
+    /// The rule applies to instances implementing a specific trait.
+    Trait(String),
+}
+
+/// A single user-defined DRC rule parsed from a `rule` block in a `trait` or
+/// `device` definition.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UserDefinedRule {
+    /// Rule name (used as `rule_id` in diagnostics, e.g. `"voltage_derating"`).
+    pub name: String,
+    /// Severity level.
+    pub level: DiagnosticLevel,
+    /// The assertion expression that must hold.  When the assertion evaluates
+    /// to `false`, a diagnostic is emitted.
+    pub assertion: RuleExpr,
+    /// Message template with `{field}` interpolation.
+    pub message_template: String,
+    /// Which instances this rule applies to.
+    pub applies_to: RuleAppliesTo,
+}
+
+/// Check whether a rule applies to a given instance.
+fn rule_matches(rule: &UserDefinedRule, inst: &Instance) -> bool {
+    match &rule.applies_to {
+        RuleAppliesTo::Device(device) => inst.device == *device,
+        RuleAppliesTo::Trait(trait_name) => inst
+            .generic_substitutions
+            .get("impl_traits")
+            .map(|traits| {
+                traits
+                    .split(',')
+                    .any(|t| t.trim() == trait_name.as_str())
+            })
+            .unwrap_or(false),
+    }
+}
+
+// ── UserDefinedRuleSet ───────────────────────────────────────────────────────
+
+/// A collection of user-defined rules that handles device-level overrides of
+/// trait-level rules.
+///
+/// When a device defines a rule with the same name as one inherited from a
+/// parent trait, the device's version takes precedence for instances of that
+/// device.
+#[derive(Debug, Clone)]
+pub struct UserDefinedRuleSet {
+    rules: Vec<UserDefinedRule>,
+}
+
+impl UserDefinedRuleSet {
+    /// Create an empty set.
+    pub fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    /// Add a rule to the set.
+    pub fn add(&mut self, rule: UserDefinedRule) {
+        self.rules.push(rule);
+    }
+
+    /// Resolve the effective rules for a given instance, applying override
+    /// semantics: if both a trait rule and a device rule share the same name,
+    /// the device rule wins.
+    fn effective_rules(&self, inst: &Instance) -> Vec<&UserDefinedRule> {
+        let mut by_name: HashMap<&str, &UserDefinedRule> = HashMap::new();
+
+        // First pass: collect trait-level rules that match.
+        for rule in &self.rules {
+            if matches!(&rule.applies_to, RuleAppliesTo::Trait(_)) && rule_matches(rule, inst) {
+                by_name.insert(&rule.name, rule);
+            }
+        }
+
+        // Second pass: device-level rules override trait-level ones.
+        for rule in &self.rules {
+            if matches!(&rule.applies_to, RuleAppliesTo::Device(_)) && rule_matches(rule, inst) {
+                by_name.insert(&rule.name, rule);
+            }
+        }
+
+        by_name.into_values().collect()
+    }
+}
+
+impl Default for UserDefinedRuleSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DrcRule for UserDefinedRuleSet {
+    fn check(&self, ir: &ConnectivityIR) -> Vec<DrcDiagnostic> {
+        let imap: HashMap<InstanceId, &Instance> =
+            ir.instances.iter().map(|i| (i.id, i)).collect();
+
+        let mut out = Vec::new();
+
+        for inst in &ir.instances {
+            let effective = self.effective_rules(inst);
+
+            for rule in effective {
+                let ctx = EvalCtx {
+                    inst,
+                    nets: &ir.nets,
+                    imap: &imap,
+                };
+
+                // Compute net_voltage for message interpolation.
+                let nv = compute_net_voltage_for_rule(&rule.assertion, &ctx);
+
+                match eval(&rule.assertion, &ctx) {
+                    Some(Value::Bool(true)) => {
+                        // Assertion holds — no diagnostic.
+                    }
+                    Some(Value::Bool(false)) => {
+                        let message =
+                            interpolate_message(&rule.message_template, inst, nv);
+                        out.push(DrcDiagnostic {
+                            rule_id: rule.name.clone(),
+                            level: rule.level,
+                            span: Span { start: 0, end: 0 },
+                            instance_path: inst.hierarchical_path.clone(),
+                            message,
+                        });
+                    }
+                    // Could not evaluate (missing data) — skip silently.
+                    _ => {}
+                }
+            }
+        }
+
+        out
+    }
+}
+
+/// Walk the expression tree to find a `NetVoltage` node and compute its value
+/// for use in message interpolation.
+fn compute_net_voltage_for_rule(expr: &RuleExpr, ctx: &EvalCtx<'_>) -> Option<f64> {
+    match expr {
+        RuleExpr::NetVoltage { .. } => {
+            if let Some(Value::Float(v)) = eval(expr, ctx) {
+                Some(v)
+            } else {
+                None
+            }
+        }
+        RuleExpr::Binary { lhs, rhs, .. } => {
+            compute_net_voltage_for_rule(lhs, ctx)
+                .or_else(|| compute_net_voltage_for_rule(rhs, ctx))
+        }
+        _ => None,
+    }
+}


### PR DESCRIPTION
Extend cohdl-drc to support user-defined rule blocks from trait and
device definitions:

- RuleExpr IR: Float, SpecField, NetVoltage, Binary operations
- UserDefinedRule: name, level, assertion, message template, applies_to
- UserDefinedRuleSet: collects rules with device-override semantics
  (device rule replaces same-named trait rule for matching instances)
- Expression evaluator resolves self.spec fields from generic_substitutions
  and net_voltage() from ConnectivityIR net analysis
- Message template interpolation with {field} placeholders
- DrcRunner.add_user_rules() integrates user diagnostics alongside built-in

Tests: voltage_derating warning from Capacitor trait (80% threshold),
stricter 50% override in Electrolytic device, suppression, arithmetic,
net voltage from instance annotations and net names.

https://claude.ai/code/session_014ucdzswNRAEfrWEzS4gnxW