### PR TITLE
Implement BOM emitter with simple and AVL output modes

### DIFF
--- a/crates/cohdl-codegen-kicad/src/bom.rs
+++ b/crates/cohdl-codegen-kicad/src/bom.rs
@@ -1,0 +1,236 @@
+//! BOM (Bill of Materials) emitters.
+//!
+//! Two output modes:
+//! - **Simple BOM** (`emit_simple_bom`): CSV with `RefDes,MPN,Qty` — groups
+//!   identical MPNs and combines reference designators.
+//! - **AVL BOM** (`emit_avl_bom`): CSV with `RefDes,Primary MPN,Alt 1,Alt 2,...`
+//!   — one row per instance, includes all alternate MPNs from `part` declarations.
+
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+use cohdl_sema::connectivity::ConnectivityIR;
+
+const UNSPECIFIED: &str = "<UNSPECIFIED>";
+
+/// Emit a simple BOM as CSV: `RefDes,MPN,Qty`.
+///
+/// Instances sharing the same MPN are grouped into a single row with combined
+/// reference designators (comma-separated) and a quantity count. Instances
+/// without a bound part appear with MPN `"<UNSPECIFIED>"`.
+pub fn emit_simple_bom(ir: &ConnectivityIR) -> String {
+    // Group by MPN → sorted list of RefDes.
+    let mut groups: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+
+    for inst in &ir.instances {
+        let mpn = inst.mpn.as_deref().unwrap_or(UNSPECIFIED);
+        groups.entry(mpn).or_default().push(&inst.name);
+    }
+
+    let mut out = String::new();
+    writeln!(out, "RefDes,MPN,Qty").unwrap();
+
+    for (mpn, mut refs) in groups {
+        refs.sort();
+        let qty = refs.len();
+        let refdes = refs.join(",");
+        writeln!(out, "\"{}\",\"{}\",{}", refdes, mpn, qty).unwrap();
+    }
+
+    out
+}
+
+/// Emit an AVL BOM as CSV: `RefDes,Primary MPN,Alt 1,Alt 2,...`.
+///
+/// Each instance gets its own row. The number of `Alt N` columns equals the
+/// maximum number of alternate MPNs across all instances. Instances without a
+/// bound part show `"<UNSPECIFIED>"` as the primary MPN with no alternates.
+pub fn emit_avl_bom(ir: &ConnectivityIR) -> String {
+    let max_alts = ir
+        .instances
+        .iter()
+        .map(|inst| inst.alt_mpns.len())
+        .max()
+        .unwrap_or(0);
+
+    let mut out = String::new();
+
+    // Header
+    write!(out, "RefDes,Primary MPN").unwrap();
+    for i in 1..=max_alts {
+        write!(out, ",Alt {}", i).unwrap();
+    }
+    writeln!(out).unwrap();
+
+    // Sort instances by name for deterministic output.
+    let mut sorted: Vec<_> = ir.instances.iter().collect();
+    sorted.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for inst in sorted {
+        let primary = inst.mpn.as_deref().unwrap_or(UNSPECIFIED);
+        write!(out, "\"{}\",\"{}\"", inst.name, primary).unwrap();
+        for i in 0..max_alts {
+            let alt = inst.alt_mpns.get(i).map(|s| s.as_str()).unwrap_or("");
+            write!(out, ",\"{}\"", alt).unwrap();
+        }
+        writeln!(out).unwrap();
+    }
+
+    out
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cohdl_sema::connectivity::{ConnectivityIR, Instance};
+    use cohdl_sema::typeck::InstanceId;
+    use std::collections::HashMap;
+
+    fn make_inst(id: u32, name: &str, mpn: Option<&str>, alt_mpns: &[&str]) -> Instance {
+        Instance {
+            id: InstanceId(id),
+            name: name.into(),
+            hierarchical_path: format!("Board::{}", name),
+            device: "DEV".into(),
+            mpn: mpn.map(|s| s.into()),
+            alt_mpns: alt_mpns.iter().map(|s| s.to_string()).collect(),
+            generic_substitutions: HashMap::new(),
+        }
+    }
+
+    // ── Simple BOM tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn simple_bom_groups_identical_mpns() {
+        let ir = ConnectivityIR {
+            instances: vec![
+                make_inst(0, "C1", Some("CL05B104KO5NNNC"), &[]),
+                make_inst(1, "C2", Some("CL05B104KO5NNNC"), &[]),
+                make_inst(2, "R1", Some("RC0402FR-0710KL"), &[]),
+            ],
+            nets: vec![],
+        };
+
+        let csv = emit_simple_bom(&ir);
+        let expected = "\
+RefDes,MPN,Qty
+\"C1,C2\",\"CL05B104KO5NNNC\",2
+\"R1\",\"RC0402FR-0710KL\",1
+";
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn simple_bom_unspecified_mpn() {
+        let ir = ConnectivityIR {
+            instances: vec![
+                make_inst(0, "U1", None, &[]),
+                make_inst(1, "C1", Some("CL05B104KO5NNNC"), &[]),
+            ],
+            nets: vec![],
+        };
+
+        let csv = emit_simple_bom(&ir);
+        let expected = "\
+RefDes,MPN,Qty
+\"U1\",\"<UNSPECIFIED>\",1
+\"C1\",\"CL05B104KO5NNNC\",1
+";
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn simple_bom_empty_ir() {
+        let ir = ConnectivityIR {
+            instances: vec![],
+            nets: vec![],
+        };
+        let csv = emit_simple_bom(&ir);
+        assert_eq!(csv, "RefDes,MPN,Qty\n");
+    }
+
+    // ── AVL BOM tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn avl_bom_includes_alternates() {
+        let ir = ConnectivityIR {
+            instances: vec![
+                make_inst(0, "C1", Some("CL05B104KO5NNNC"), &["GRM155R71C104KA88D"]),
+                make_inst(1, "R1", Some("RC0402FR-0710KL"), &[]),
+            ],
+            nets: vec![],
+        };
+
+        let csv = emit_avl_bom(&ir);
+        let expected = "\
+RefDes,Primary MPN,Alt 1
+\"C1\",\"CL05B104KO5NNNC\",\"GRM155R71C104KA88D\"
+\"R1\",\"RC0402FR-0710KL\",\"\"
+";
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn avl_bom_multiple_alternates() {
+        let ir = ConnectivityIR {
+            instances: vec![make_inst(
+                0,
+                "C1",
+                Some("CL05B104KO5NNNC"),
+                &["GRM155R71C104KA88D", "08055C104KAT2A"],
+            )],
+            nets: vec![],
+        };
+
+        let csv = emit_avl_bom(&ir);
+        let expected = "\
+RefDes,Primary MPN,Alt 1,Alt 2
+\"C1\",\"CL05B104KO5NNNC\",\"GRM155R71C104KA88D\",\"08055C104KAT2A\"
+";
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn avl_bom_unspecified_mpn() {
+        let ir = ConnectivityIR {
+            instances: vec![make_inst(0, "U1", None, &[])],
+            nets: vec![],
+        };
+
+        let csv = emit_avl_bom(&ir);
+        let expected = "\
+RefDes,Primary MPN
+\"U1\",\"<UNSPECIFIED>\"
+";
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn avl_bom_empty_ir() {
+        let ir = ConnectivityIR {
+            instances: vec![],
+            nets: vec![],
+        };
+        let csv = emit_avl_bom(&ir);
+        assert_eq!(csv, "RefDes,Primary MPN\n");
+    }
+
+    #[test]
+    fn avl_bom_sorted_by_refdes() {
+        let ir = ConnectivityIR {
+            instances: vec![
+                make_inst(0, "R1", Some("RC0402FR-0710KL"), &[]),
+                make_inst(1, "C1", Some("CL05B104KO5NNNC"), &[]),
+            ],
+            nets: vec![],
+        };
+
+        let csv = emit_avl_bom(&ir);
+        // C1 should come before R1 in sorted output.
+        let lines: Vec<&str> = csv.lines().collect();
+        assert!(lines[1].starts_with("\"C1\""));
+        assert!(lines[2].starts_with("\"R1\""));
+    }
+}

--- a/crates/cohdl-codegen-kicad/src/lib.rs
+++ b/crates/cohdl-codegen-kicad/src/lib.rs
@@ -3,6 +3,9 @@
 //! Generates a netlist string from a [`ConnectivityIR`] that can be imported
 //! into KiCad via **File → Import Netlist**.
 
+mod bom;
+pub use bom::{emit_avl_bom, emit_simple_bom};
+
 use std::collections::HashMap;
 use std::fmt::Write;
 
@@ -177,6 +180,7 @@ mod tests {
                     hierarchical_path: "Board::U1".into(),
                     device: "LQFP48".into(),
                     mpn: Some("STM32F103C8T6".into()),
+                    alt_mpns: vec![],
                     generic_substitutions: {
                         let mut m = HashMap::new();
                         m.insert("value".to_string(), "STM32F103".to_string());
@@ -189,6 +193,7 @@ mod tests {
                     hierarchical_path: "Board::R1".into(),
                     device: "R0402".into(),
                     mpn: None,
+                    alt_mpns: vec![],
                     generic_substitutions: {
                         let mut m = HashMap::new();
                         m.insert("value".to_string(), "10k".to_string());
@@ -201,6 +206,7 @@ mod tests {
                     hierarchical_path: "Board::C1".into(),
                     device: "C0402".into(),
                     mpn: None,
+                    alt_mpns: vec![],
                     generic_substitutions: {
                         let mut m = HashMap::new();
                         m.insert("value".to_string(), "100nF".to_string());
@@ -350,6 +356,7 @@ mod tests {
                 hierarchical_path: "Board::X1".into(),
                 device: "MY_CUSTOM_PKG".into(),
                 mpn: None,
+                alt_mpns: vec![],
                 generic_substitutions: HashMap::new(),
             }],
             nets: vec![],
@@ -367,6 +374,7 @@ mod tests {
                 hierarchical_path: "Board::U1".into(),
                 device: "QFN32".into(),
                 mpn: None,
+                alt_mpns: vec![],
                 generic_substitutions: HashMap::new(),
             }],
             nets: vec![],
@@ -388,6 +396,7 @@ mod tests {
                 hierarchical_path: "Board::U1".into(),
                 device: "R0402".into(),
                 mpn: Some("Part<1>&\"2\"".into()),
+                alt_mpns: vec![],
                 generic_substitutions: {
                     let mut m = HashMap::new();
                     m.insert("value".to_string(), "R<10>".to_string());

--- a/crates/cohdl-drc/src/tests.rs
+++ b/crates/cohdl-drc/src/tests.rs
@@ -16,6 +16,7 @@ fn inst(id: u32, name: &str, device: &str, subs: &[(&str, &str)]) -> Instance {
         hierarchical_path: format!("Board::{}", name),
         device: device.to_string(),
         mpn: None,
+        alt_mpns: vec![],
         generic_substitutions: subs
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))

--- a/crates/cohdl-sema/src/connectivity.rs
+++ b/crates/cohdl-sema/src/connectivity.rs
@@ -50,6 +50,8 @@ pub struct Instance {
     pub device: String,
     /// Primary MPN if backed by a part.
     pub mpn: Option<String>,
+    /// Alternate MPNs from the part's AVL entries.
+    pub alt_mpns: Vec<String>,
     /// Generic parameter substitutions.
     pub generic_substitutions: HashMap<String, String>,
 }
@@ -137,6 +139,7 @@ pub fn build_connectivity(
             hierarchical_path: format!("{}::{}", design.name, ci.name),
             device: ci.device.clone(),
             mpn: ci.mpn.clone(),
+            alt_mpns: ci.alt_mpns.clone(),
             generic_substitutions: ci.generic_substitutions.clone(),
         })
         .collect();
@@ -360,6 +363,7 @@ mod tests {
             name: name.to_string(),
             device: device.to_string(),
             mpn: None,
+            alt_mpns: Vec::new(),
             generic_substitutions: HashMap::new(),
             designator_override: None,
             impl_traits: Vec::new(),
@@ -638,6 +642,7 @@ mod tests {
                 name: "c1".into(),
                 device: "MLCC".into(),
                 mpn: Some("CL05B104KO5NNNC".into()),
+                alt_mpns: Vec::new(),
                 generic_substitutions: subs.clone(),
                 designator_override: None,
                 impl_traits: Vec::new(),

--- a/crates/cohdl-sema/src/designator.rs
+++ b/crates/cohdl-sema/src/designator.rs
@@ -561,6 +561,7 @@ mod tests {
                     hierarchical_path: "Board::c1".into(),
                     device: "MLCC".into(),
                     mpn: None,
+                    alt_mpns: vec![],
                     generic_substitutions: HashMap::new(),
                 },
                 Instance {
@@ -569,6 +570,7 @@ mod tests {
                     hierarchical_path: "Board::mcu".into(),
                     device: "STM32".into(),
                     mpn: None,
+                    alt_mpns: vec![],
                     generic_substitutions: HashMap::new(),
                 },
             ],

--- a/crates/cohdl-sema/src/typeck.rs
+++ b/crates/cohdl-sema/src/typeck.rs
@@ -90,6 +90,8 @@ pub struct ComponentInstance {
     pub device: std::string::String,
     /// If this instance is backed by a `part`, the primary MPN.
     pub mpn: Option<std::string::String>,
+    /// Alternate MPNs from the part's AVL entries.
+    pub alt_mpns: Vec<std::string::String>,
     /// Generic parameter substitutions (param name → resolved value string).
     pub generic_substitutions: HashMap<std::string::String, std::string::String>,
     /// Explicit designator override from `#[designator("U1")]`.
@@ -171,6 +173,8 @@ struct PartDef {
     generic_args: HashMap<std::string::String, std::string::String>,
     /// Primary MPN from the AVL.
     primary_mpn: Option<std::string::String>,
+    /// Alternate MPNs from the AVL.
+    alt_mpns: Vec<std::string::String>,
 }
 
 /// A collected function definition.
@@ -342,12 +346,25 @@ impl TypeChecker {
                     .map(|f| f.value.value.clone())
             });
 
+        let alt_mpns: Vec<std::string::String> = p
+            .avl_entries
+            .iter()
+            .filter(|e| e.kind == ast::AvlKind::Alt)
+            .filter_map(|e| {
+                e.fields
+                    .iter()
+                    .find(|f| f.name.name == "mpn")
+                    .map(|f| f.value.value.clone())
+            })
+            .collect();
+
         self.parts.insert(
             qname.clone(),
             PartDef {
                 device_name,
                 generic_args,
                 primary_mpn,
+                alt_mpns,
             },
         );
     }
@@ -622,15 +639,16 @@ impl TypeChecker {
                 let (device_name, base_args) = self.resolve_type_name(&type_name, module_path);
 
                 // Check if this is a part or a device.
-                let (final_device, mpn, part_args) =
+                let (final_device, mpn, alt_mpns, part_args) =
                     if let Some(part) = self.find_part(&type_name, module_path) {
                         (
                             part.device_name.clone(),
                             part.primary_mpn.clone(),
+                            part.alt_mpns.clone(),
                             part.generic_args.clone(),
                         )
                     } else {
-                        (device_name.clone(), None, HashMap::new())
+                        (device_name.clone(), None, Vec::new(), HashMap::new())
                     };
 
                 // Merge args: base_args (from alias) < part_args < inst args.
@@ -688,6 +706,7 @@ impl TypeChecker {
                     name: inst.name.name.clone(),
                     device: final_device,
                     mpn,
+                    alt_mpns,
                     generic_substitutions: all_args,
                     designator_override,
                     impl_traits,


### PR DESCRIPTION
Add emit_simple_bom (CSV: RefDes,MPN,Qty with MPN grouping) and
emit_avl_bom (CSV: RefDes,Primary MPN,Alt 1,...) to cohdl-codegen-kicad.
Thread alt_mpns from part AVL entries through PartDef, ComponentInstance,
and connectivity::Instance so alternate MPNs are available at codegen time.
Instances without a bound part show MPN as "<UNSPECIFIED>".

https://claude.ai/code/session_01AvJ3ygqQ4Pzno3rRHFiJpS