### PR TITLE
Add VS Code syntax highlighting for cohdl language

### DIFF
--- a/editors/vscode/examples/stm32_usb.cohdl
+++ b/editors/vscode/examples/stm32_usb.cohdl
@@ -1,0 +1,122 @@
+// STM32 USB Power Supply — exercises every token category
+// for visual grammar testing in VS Code.
+
+/* Block comment: full design of an STM32-based
+   USB-C power delivery board. */
+
+use std::io;
+use chips::st::STM32G431;
+use passives::capacitor::MLCC;
+
+// ---------- type aliases ----------
+type SupplyVoltage = Voltage;
+type DecouplingCap = Capacitance;
+
+// ---------- trait ----------
+trait PowerRegulator {
+    fn output_voltage() -> Voltage;
+    fn max_current() -> Net;
+}
+
+// ---------- device ----------
+#[designator("U")]
+pub device STM32G4 {
+    pins {
+        vdd:   Pin<Net>,
+        vss:   Pin<Net>,
+        usb_dp: Pin<Net>,
+        usb_dm: Pin<Net>,
+        pa0:   Pin<Net>,
+        pa1:   Pin<Net>,
+    }
+
+    spec {
+        rule vdd_decoupling {
+            primary: inst bypass_cap = MLCC { value: 100nF };
+            alt:     inst bulk_cap  = MLCC { value: 4.7uF };
+        }
+    }
+}
+
+// ---------- part ----------
+#[designator("C")]
+part CeramicCap {
+    value: Farads,
+    package: Package,
+}
+
+#[designator("R")]
+part Resistor {
+    value: Ohms,
+    package: Package,
+}
+
+#[designator("L")]
+part Inductor {
+    value: Henries,
+    package: Package,
+}
+
+// ---------- impl ----------
+impl PowerRegulator for STM32G4 {
+    fn output_voltage() -> Voltage {
+        3.3V
+    }
+
+    fn max_current() -> Net {
+        net usb_vbus
+    }
+}
+
+// ---------- module ----------
+pub module UsbPhy {
+    inst mcu = STM32G4;
+
+    // Bus macro invocations
+    pin_bus!(data, 2);
+
+    net usb_dp;
+    net usb_dm;
+
+    inst r_dp = Resistor { value: 22R, package: Package::R0402 };
+    inst r_dm = Resistor { value: 22R, package: Package::R0402 };
+
+    inst esd_cap = CeramicCap { value: 100pF, package: Package::C0201 };
+}
+
+// ---------- design (top-level) ----------
+#[allow(unused)]
+pub design StmUsbBoard {
+    inst phy = UsbPhy;
+
+    // Decoupling network
+    inst c1 = CeramicCap { value: 100nF, package: Package::C0402 };
+    inst c2 = CeramicCap { value: 4.7uF, package: Package::C0805 };
+    inst c3 = CeramicCap { value: 10uF,  package: Package::C0805 };
+
+    // Pull-up resistor
+    inst r_pullup = Resistor { value: 10k, package: Package::R0402 };
+
+    // Ferrite / inductor for power filtering
+    inst l_filter = Inductor { value: 2.2uH, package: Package::L0603 };
+
+    // Engineering-notation numeric literals of every unit
+    fn voltage_divider() {
+        let vref     = 1.25V;
+        let r_top    = 10k;
+        let r_bottom = 4.7k;
+        let c_filter = 22nF;
+        let l_choke  = 100uH;
+        let freq     = 48MHz;
+        let esr      = 0.1Ohm;
+        let plain    = 48;
+        let decimal  = 0.1;
+        let pico     = 33pF;
+        let mega     = 8MH;
+        let giga     = 1GHz;
+        let tera     = 1THz;
+    }
+
+    // Macro usage (macro keyword + macro! invocation)
+    macro generate_nets! count(8);
+}

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,29 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": [
+      "/*",
+      "*/"
+    ]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["<", ">"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "<", "close": ">" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "<", "close": ">" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ]
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "cohdl-lang",
+  "displayName": "cohdl PCB HDL",
+  "description": "Syntax highlighting for the cohdl hardware description language",
+  "version": "0.1.0",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:cohdl"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "cohdl",
+        "aliases": [
+          "cohdl",
+          "COHDL"
+        ],
+        "extensions": [
+          ".cohdl"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "cohdl",
+        "scopeName": "source.cohdl",
+        "path": "./syntaxes/cohdl.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/editors/vscode/syntaxes/cohdl.tmLanguage.json
+++ b/editors/vscode/syntaxes/cohdl.tmLanguage.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "cohdl",
+  "scopeName": "source.cohdl",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#attributes" },
+    { "include": "#strings" },
+    { "include": "#macros" },
+    { "include": "#keywords" },
+    { "include": "#builtinTypes" },
+    { "include": "#numerics" },
+    { "include": "#scopedPath" },
+    { "include": "#typeNames" },
+    { "include": "#identifiers" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.cohdl",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.block.cohdl",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.cohdl",
+          "match": "\\b(trait|device|part|type|fn|module|design|use|pub|inst|net|impl|pins|spec|rule|primary|alt|macro)\\b"
+        }
+      ]
+    },
+    "builtinTypes": {
+      "patterns": [
+        {
+          "name": "support.type.cohdl",
+          "match": "\\b(Net|Pin|Package|Farads|Voltage|Ohms|Henries|Capacitance|Inductance)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.cohdl",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.cohdl",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "numerics": {
+      "patterns": [
+        {
+          "name": "constant.numeric.cohdl",
+          "match": "-?[0-9]+(\\.[0-9]+)?([munpkMGT]?(F|V|R|H|Hz|Ohm)?)\\b"
+        }
+      ]
+    },
+    "attributes": {
+      "patterns": [
+        {
+          "name": "meta.attribute.cohdl",
+          "begin": "(#\\[)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.attribute.cohdl" }
+          },
+          "end": "(\\])",
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.attribute.cohdl" }
+          },
+          "patterns": [
+            {
+              "name": "entity.other.attribute-name.cohdl",
+              "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+            },
+            { "include": "#strings" }
+          ]
+        }
+      ]
+    },
+    "macros": {
+      "patterns": [
+        {
+          "name": "meta.macro.cohdl",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(!)",
+          "captures": {
+            "1": { "name": "entity.name.function.macro.cohdl" },
+            "2": { "name": "keyword.operator.macro.cohdl" }
+          }
+        }
+      ]
+    },
+    "scopedPath": {
+      "patterns": [
+        {
+          "name": "punctuation.accessor.cohdl",
+          "match": "::"
+        }
+      ]
+    },
+    "typeNames": {
+      "patterns": [
+        {
+          "name": "entity.name.type.cohdl",
+          "match": "\\b[A-Z][a-zA-Z0-9]*\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.cohdl",
+          "match": "\\b[a-z_][a-z0-9_]*\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "punctuation.cohdl",
+          "match": "[{}\\[\\]<>(),:\\.!=]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds complete VS Code extension support for the cohdl PCB hardware description language, including syntax highlighting, language configuration, and example code.

## Key Changes
- **Syntax Grammar** (`syntaxes/cohdl.tmLanguage.json`): Comprehensive TextMate grammar definition supporting:
  - Comments (line and block)
  - Keywords (trait, device, part, type, fn, module, design, use, pub, inst, net, impl, pins, spec, rule, primary, alt, macro)
  - Built-in types (Net, Pin, Package, Farads, Voltage, Ohms, Henries, Capacitance, Inductance)
  - String literals with escape sequences
  - Numeric literals with engineering notation (m, u, n, p, k, M, G, T) and unit suffixes (F, V, R, H, Hz, Ohm)
  - Attributes (`#[...]`)
  - Macro invocations (`name!`)
  - Scoped paths (`::`)
  - Type names (PascalCase convention)
  - Identifiers and operators

- **Extension Manifest** (`package.json`): VS Code extension configuration with:
  - Language registration for `.cohdl` files
  - Activation on cohdl language files
  - Grammar and language configuration references

- **Language Configuration** (`language-configuration.json`): Editor behavior settings including:
  - Comment syntax (// and /* */)
  - Bracket matching and auto-closing pairs
  - Surrounding pair support

- **Example File** (`examples/stm32_usb.cohdl`): Comprehensive example demonstrating all language features including traits, devices, parts, modules, designs, numeric literals with units, and macro usage.

## Implementation Details
The syntax highlighting uses a modular pattern-based approach with a repository of reusable patterns, enabling consistent highlighting across different contexts. The grammar properly handles cohdl-specific constructs like device specifications with primary/alternative rules and engineering-notation numeric literals commonly used in PCB design.

https://claude.ai/code/session_013cpVDq2LMoryJtutf2kqdf