### PR TITLE
Add `init` subcommand to scaffold new cohdl projects

### DIFF
--- a/crates/cohdl-cli/src/main.rs
+++ b/crates/cohdl-cli/src/main.rs
@@ -68,6 +68,11 @@ enum Command {
     Check,
     /// Format source files (placeholder)
     Fmt,
+    /// Initialize a new cohdl project
+    Init {
+        /// Project name (defaults to directory name)
+        name: Option<String>,
+    },
 }
 
 #[derive(Clone, ValueEnum, PartialEq, Eq)]
@@ -537,6 +542,86 @@ fn cmd_check(stderr: &mut StandardStream) -> i32 {
     }
 }
 
+fn cmd_init(stderr: &mut StandardStream, name: Option<String>) -> i32 {
+    // Determine project name: explicit arg > current directory name > fallback
+    let project_name = match name {
+        Some(n) => n,
+        None => std::env::current_dir()
+            .ok()
+            .and_then(|p| p.file_name().map(|f| f.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "my-project".to_string()),
+    };
+
+    // Refuse to overwrite an existing cohdl.toml
+    if std::path::Path::new("cohdl.toml").exists() {
+        stderr
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
+            .ok();
+        write!(stderr, "Error").ok();
+        stderr.reset().ok();
+        writeln!(stderr, ": cohdl.toml already exists").ok();
+        return 1;
+    }
+
+    let manifest = format!(
+        r#"[package]
+name    = "{}"
+version = "0.1.0"
+
+[design]
+root = "src/main.cohdl"
+top  = "MainBoard"
+"#,
+        project_name
+    );
+
+    let starter_source = r#"design MainBoard {
+}
+"#;
+
+    if let Err(e) = fs::create_dir_all("src") {
+        stderr
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
+            .ok();
+        write!(stderr, "Error").ok();
+        stderr.reset().ok();
+        writeln!(stderr, ": could not create src directory: {}", e).ok();
+        return 1;
+    }
+
+    if let Err(e) = fs::write("cohdl.toml", &manifest) {
+        stderr
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
+            .ok();
+        write!(stderr, "Error").ok();
+        stderr.reset().ok();
+        writeln!(stderr, ": could not write cohdl.toml: {}", e).ok();
+        return 1;
+    }
+
+    let source_path = std::path::Path::new("src/main.cohdl");
+    if !source_path.exists() {
+        if let Err(e) = fs::write(source_path, starter_source) {
+            stderr
+                .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
+                .ok();
+            write!(stderr, "Error").ok();
+            stderr.reset().ok();
+            writeln!(stderr, ": could not write src/main.cohdl: {}", e).ok();
+            return 1;
+        }
+    }
+
+    stderr
+        .set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))
+        .ok();
+    write!(stderr, "  Created").ok();
+    stderr.reset().ok();
+    writeln!(stderr, " project `{}`", project_name).ok();
+
+    0
+}
+
 // ── main ────────────────────────────────────────────────────────────────────
 
 fn main() {
@@ -554,6 +639,7 @@ fn main() {
             println!("formatter not yet implemented");
             0
         }
+        Command::Init { name } => cmd_init(&mut stderr, name),
     };
 
     process::exit(exit_code);

--- a/crates/cohdl-cli/tests/cli_integration.rs
+++ b/crates/cohdl-cli/tests/cli_integration.rs
@@ -242,6 +242,72 @@ fn color_flag_never() {
     cohdl().args(["--color", "never", "fmt"]).assert().success();
 }
 
+// ── init subcommand ─────────────────────────────────────────────────────────
+
+#[test]
+fn init_creates_project_files() {
+    let dir = TempDir::new().unwrap();
+    cohdl()
+        .args(["init", "my-board"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Created").and(predicate::str::contains("my-board")));
+
+    let manifest = fs::read_to_string(dir.path().join("cohdl.toml")).unwrap();
+    assert!(manifest.contains("my-board"));
+    assert!(manifest.contains("[package]"));
+    assert!(manifest.contains("[design]"));
+    assert!(dir.path().join("src/main.cohdl").exists());
+}
+
+#[test]
+fn init_defaults_name_to_dir() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("cool-project");
+    fs::create_dir_all(&project_dir).unwrap();
+
+    cohdl()
+        .arg("init")
+        .current_dir(&project_dir)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("cool-project"));
+
+    let manifest = fs::read_to_string(project_dir.join("cohdl.toml")).unwrap();
+    assert!(manifest.contains("cool-project"));
+}
+
+#[test]
+fn init_fails_if_manifest_exists() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("cohdl.toml"), "existing").unwrap();
+
+    cohdl()
+        .args(["init", "test"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cohdl.toml already exists"));
+}
+
+#[test]
+fn init_then_check_works() {
+    let dir = TempDir::new().unwrap();
+    cohdl()
+        .args(["init", "test-board"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // The initialized project should be valid enough for `check` to succeed
+    cohdl()
+        .arg("check")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
 // ── diagnostic output contains source span ──────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
This PR adds a new `init` subcommand to the cohdl CLI that scaffolds a new cohdl project with the necessary directory structure and configuration files.

## Key Changes
- **New `init` subcommand**: Allows users to initialize a new cohdl project with an optional project name argument
  - If no name is provided, defaults to the current directory name
  - Falls back to "my-project" if directory name cannot be determined
- **Project scaffolding**: Creates the following structure:
  - `cohdl.toml` manifest file with package metadata and design configuration
  - `src/` directory with a starter `main.cohdl` file containing an empty `MainBoard` design
- **Safety checks**: Refuses to overwrite an existing `cohdl.toml` file to prevent accidental data loss
- **Error handling**: Provides clear error messages for file system operations (directory creation, file writing)
- **User feedback**: Displays a success message with the created project name in green text
- **Comprehensive tests**: Added 4 integration tests covering:
  - Basic project file creation with explicit name
  - Default naming from directory name
  - Failure when manifest already exists
  - Integration with the `check` subcommand on initialized projects

## Implementation Details
- The command follows the existing CLI pattern with proper error codes (0 for success, 1 for failure)
- Uses the same colored output styling as other commands for consistency
- Starter template includes minimal but valid cohdl syntax to ensure initialized projects pass validation

https://claude.ai/code/session_019uQ5h78yj9RQBwRiFFG3yz