### PR TITLE
Add VS Code extension with language server integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,22 @@ jobs:
             ${{ runner.os }}-cargo-
       - run: cargo doc --workspace --no-deps
 
+  vscode-ext:
+    name: VS Code Extension
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editors/vscode
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+      - run: npm ci
+      - run: npm run compile
+
   mdbook:
     name: mdBook
     runs-on: ubuntu-latest

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+out/
+node_modules/
+*.vsix

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,3 @@
+src/
+node_modules/
+tsconfig.json

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,61 @@
+# cohdl VS Code Extension
+
+Language support for the cohdl hardware description language, including syntax
+highlighting and integration with the `cohdl-lsp` language server.
+
+## Development
+
+1. Install dependencies:
+
+   ```sh
+   cd editors/vscode
+   npm install
+   ```
+
+2. Open the `editors/vscode/` folder in VS Code.
+
+3. Press **F5** to launch the Extension Development Host with the extension
+   loaded.
+
+## Building and Installing
+
+1. Install the VS Code Extension packaging tool:
+
+   ```sh
+   npm install -g @vscode/vsce
+   ```
+
+2. Build the `.vsix` package:
+
+   ```sh
+   cd editors/vscode
+   vsce package
+   ```
+
+   This produces `cohdl-lang-0.1.0.vsix`.
+
+3. Install the extension:
+
+   ```sh
+   code --install-extension cohdl-lang-0.1.0.vsix
+   ```
+
+## Configuration
+
+### `cohdl.serverPath`
+
+Absolute path to the `cohdl-lsp` binary. If left empty (the default), the
+extension looks for `cohdl-lsp` on your `PATH`.
+
+Open **Settings** and search for `cohdl.serverPath`, then set it to the full
+path of your compiled `cohdl-lsp` binary, for example:
+
+```
+/home/you/cohdl/target/release/cohdl-lsp
+```
+
+### Restart Language Server
+
+Run the **cohdl: Restart Language Server** command from the Command Palette
+(`Ctrl+Shift+P`) to stop and restart the language server without reloading the
+window.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,139 @@
+{
+  "name": "cohdl-lang",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cohdl-lang",
+      "version": "0.1.0",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.80.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.80.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cohdl-lang",
   "displayName": "cohdl PCB HDL",
-  "description": "Syntax highlighting for the cohdl hardware description language",
+  "description": "Syntax highlighting and language server support for the cohdl hardware description language",
   "version": "0.1.0",
   "engines": {
     "vscode": "^1.80.0"
@@ -12,6 +12,7 @@
   "activationEvents": [
     "onLanguage:cohdl"
   ],
+  "main": "./out/extension.js",
   "contributes": {
     "languages": [
       {
@@ -32,6 +33,35 @@
         "scopeName": "source.cohdl",
         "path": "./syntaxes/cohdl.tmLanguage.json"
       }
+    ],
+    "configuration": {
+      "title": "cohdl",
+      "properties": {
+        "cohdl.serverPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the cohdl-lsp binary. Leave empty to use PATH."
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "cohdl.restartServer",
+        "title": "cohdl: Restart Language Server"
+      }
     ]
+  },
+  "scripts": {
+    "compile": "tsc",
+    "watch": "tsc -w",
+    "vscode:prepublish": "npm run compile"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.80.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,91 @@
+import * as vscode from "vscode";
+import * as cp from "child_process";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+function findOnPath(name: string): string | undefined {
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    return cp.execFileSync(cmd, [name], { encoding: "utf-8" }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function findServerBinary(): string | undefined {
+  const configured = vscode.workspace
+    .getConfiguration("cohdl")
+    .get<string>("serverPath");
+
+  if (configured) {
+    return configured;
+  }
+
+  return findOnPath("cohdl-lsp");
+}
+
+async function startClient(
+  context: vscode.ExtensionContext
+): Promise<void> {
+  const serverPath = findServerBinary();
+
+  if (!serverPath) {
+    vscode.window.showErrorMessage(
+      "Could not find the cohdl-lsp binary. " +
+        "Set cohdl.serverPath in settings or ensure cohdl-lsp is on your PATH."
+    );
+    return;
+  }
+
+  const serverOptions: ServerOptions = {
+    command: serverPath,
+    transport: TransportKind.stdio,
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: "file", language: "cohdl" }],
+    synchronize: {
+      fileEvents: [
+        vscode.workspace.createFileSystemWatcher("**/*.cohdl"),
+        vscode.workspace.createFileSystemWatcher("**/cohdl.toml"),
+      ],
+    },
+  };
+
+  client = new LanguageClient(
+    "cohdl-lsp",
+    "cohdl Language Server",
+    serverOptions,
+    clientOptions
+  );
+
+  await client.start();
+}
+
+export async function activate(
+  context: vscode.ExtensionContext
+): Promise<void> {
+  await startClient(context);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("cohdl.restartServer", async () => {
+      if (client) {
+        await client.stop();
+        client = undefined;
+      }
+      await startClient(context);
+    })
+  );
+}
+
+export async function deactivate(): Promise<void> {
+  if (client) {
+    await client.stop();
+  }
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
This PR adds a fully functional VS Code extension for cohdl that integrates with the `cohdl-lsp` language server, providing real-time language features beyond syntax highlighting.

## Key Changes
- **Extension implementation** (`extension.ts`): Added TypeScript extension code that:
  - Launches and manages the `cohdl-lsp` language server process
  - Discovers the server binary via configuration or PATH lookup
  - Monitors `.cohdl` and `cohdl.toml` files for changes
  - Provides a "Restart Language Server" command accessible from the Command Palette

- **Configuration support**: Added `cohdl.serverPath` setting to allow users to specify a custom path to the `cohdl-lsp` binary

- **Build tooling**: Added TypeScript configuration and npm scripts for compilation and packaging

- **Documentation**: Added comprehensive README with setup, building, installation, and configuration instructions

- **Project configuration**: Updated `package.json` to include language server dependencies, build scripts, and command/configuration contributions

## Notable Implementation Details
- Uses stdio transport for language server communication
- Gracefully handles missing `cohdl-lsp` binary with user-friendly error messages
- Supports both Windows (`where`) and Unix-like (`which`) systems for PATH lookup
- Includes proper cleanup on extension deactivation
- Configured for VS Code 1.80.0+

https://claude.ai/code/session_01VBCL7gzsvJ9jKLaQrUF34L