### PR TITLE
Add automated release workflow for multi-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-release-
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p cohdl-cli
+
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../cohdl-${{ matrix.target }}.tar.gz cohdl
+          cd ../../..
+
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a ../../../cohdl-${{ matrix.target }}.zip cohdl.exe
+          cd ../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cohdl-${{ matrix.target }}
+          path: cohdl-${{ matrix.target }}.*
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,30 @@ jobs:
           name: cohdl-${{ matrix.target }}
           path: cohdl-${{ matrix.target }}.*
 
+  vscode-ext:
+    name: VS Code Extension
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editors/vscode
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+      - run: npm ci
+      - run: npx @vscode/vsce package --no-dependencies -o cohdl-lang.vsix
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cohdl-lang-vsix
+          path: editors/vscode/cohdl-lang.vsix
+
   release:
     name: Release
-    needs: build
+    needs: [build, vscode-ext]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive GitHub Actions workflow for automating releases of the cohdl project across multiple platforms and packaging formats.

## Key Changes
- **Multi-platform binary builds**: Automated compilation for Linux (x86_64 and ARM64), macOS (Intel and Apple Silicon), and Windows targets
- **Cross-compilation support**: Configured toolchain for ARM64 Linux builds using gcc-aarch64-linux-gnu
- **Platform-specific packaging**: Tar.gz archives for Unix-like systems and ZIP archives for Windows
- **VS Code extension packaging**: Automated build and packaging of the VS Code language extension
- **Automated release creation**: Uses softprops/action-gh-release to create GitHub releases with all artifacts and auto-generated release notes

## Implementation Details
- Workflow triggers on version tags matching the pattern `v*`
- Implements build caching for Cargo dependencies to optimize build times
- Separate jobs for binary builds (matrix strategy), VS Code extension, and final release creation
- Release job depends on successful completion of build and vscode-ext jobs
- All artifacts are merged and uploaded to the GitHub release

https://claude.ai/code/session_01AZpo9UcbhdnXUmCDFNvs45