### PR TITLE
Implement module resolution for multi-file CoHDL projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+out/

--- a/crates/cohdl-cli/src/main.rs
+++ b/crates/cohdl-cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -108,6 +108,56 @@ fn load_manifest() -> Result<CohdlManifest, String> {
     let content = fs::read_to_string("cohdl.toml")
         .map_err(|e| format!("could not read cohdl.toml: {}", e))?;
     toml::from_str(&content).map_err(|e| format!("invalid cohdl.toml: {}", e))
+}
+
+/// Resolve `module <name>` declarations in the root source file.
+///
+/// Parses the root file to find `ModDecl` nodes, loads each referenced
+/// `<name>.cohdl` from the same directory, and returns the combined source
+/// with module files prepended before the root source (like Rust's `mod`).
+fn resolve_modules(root_path: &str, root_src: &str) -> Result<String, String> {
+    use cohdl_syntax::ast::TopLevelItemKind;
+
+    let source_file = match parse_source_file(root_src) {
+        Ok(sf) => sf,
+        // Parse errors will be reported with full diagnostics by run_pipeline;
+        // just return the root source as-is so the pipeline can handle it.
+        Err(_) => return Ok(root_src.to_string()),
+    };
+
+    let mod_names: Vec<&str> = source_file
+        .items
+        .iter()
+        .filter_map(|item| match &item.kind {
+            TopLevelItemKind::Mod(m) => Some(m.name.name.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    if mod_names.is_empty() {
+        return Ok(root_src.to_string());
+    }
+
+    let src_dir = Path::new(root_path)
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+
+    let mut combined = String::new();
+    for name in &mod_names {
+        let mod_path = src_dir.join(format!("{}.cohdl", name));
+        let content = fs::read_to_string(&mod_path).map_err(|e| {
+            format!(
+                "could not read module `{}` ({}): {}",
+                name,
+                mod_path.display(),
+                e
+            )
+        })?;
+        combined.push_str(&content);
+        combined.push('\n');
+    }
+    combined.push_str(root_src);
+    Ok(combined)
 }
 
 // ── Diagnostic rendering ────────────────────────────────────────────────────
@@ -434,7 +484,7 @@ fn cmd_build(
     let top_design = design_override.as_deref().unwrap_or(&manifest.design.top);
     let file_path = &manifest.design.root;
 
-    let src = match fs::read_to_string(file_path) {
+    let root_src = match fs::read_to_string(file_path) {
         Ok(s) => s,
         Err(e) => {
             stderr
@@ -443,6 +493,19 @@ fn cmd_build(
             write!(stderr, "Error").ok();
             stderr.reset().ok();
             writeln!(stderr, ": could not read {}: {}", file_path, e).ok();
+            return 1;
+        }
+    };
+
+    let src = match resolve_modules(file_path, &root_src) {
+        Ok(s) => s,
+        Err(e) => {
+            stderr
+                .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
+                .ok();
+            write!(stderr, "Error").ok();
+            stderr.reset().ok();
+            writeln!(stderr, ": {}", e).ok();
             return 1;
         }
     };
@@ -519,7 +582,7 @@ fn cmd_check(stderr: &mut StandardStream) -> i32 {
     };
 
     let file_path = &manifest.design.root;
-    let src = match fs::read_to_string(file_path) {
+    let root_src = match fs::read_to_string(file_path) {
         Ok(s) => s,
         Err(e) => {
             stderr
@@ -528,6 +591,19 @@ fn cmd_check(stderr: &mut StandardStream) -> i32 {
             write!(stderr, "Error").ok();
             stderr.reset().ok();
             writeln!(stderr, ": could not read {}: {}", file_path, e).ok();
+            return 1;
+        }
+    };
+
+    let src = match resolve_modules(file_path, &root_src) {
+        Ok(s) => s,
+        Err(e) => {
+            stderr
+                .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
+                .ok();
+            write!(stderr, "Error").ok();
+            stderr.reset().ok();
+            writeln!(stderr, ": {}", e).ok();
             return 1;
         }
     };

--- a/crates/cohdl-cli/tests/cli_integration.rs
+++ b/crates/cohdl-cli/tests/cli_integration.rs
@@ -193,7 +193,9 @@ fn build_missing_module_file_exits_1() {
         .current_dir(dir.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("could not read module `nonexistent`"));
+        .stderr(predicate::str::contains(
+            "could not read module `nonexistent`",
+        ));
 }
 
 // ── build with custom out-dir ───────────────────────────────────────────────

--- a/crates/cohdl-cli/tests/cli_integration.rs
+++ b/crates/cohdl-cli/tests/cli_integration.rs
@@ -124,6 +124,78 @@ fn build_valid_source_produces_netlist() {
     assert!(dir.path().join("out/test-board-bom-avl.csv").exists());
 }
 
+// ── build with module declarations resolves multi-file projects ─────────────
+
+#[test]
+fn build_multi_file_with_module_decl() {
+    let dir = TempDir::new().unwrap();
+
+    let manifest = r#"[package]
+name    = "test-board"
+version = "0.1.0"
+
+[design]
+root = "src/main.cohdl"
+top  = "MainBoard"
+"#;
+
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("cohdl.toml"), manifest).unwrap();
+
+    // Module file: defines the device
+    fs::write(
+        dir.path().join("src/parts.cohdl"),
+        r#"
+        trait TwoTerminal {
+            pins { A: Pin, B: Pin }
+        }
+        device MLCC<C: Farads, V: Voltage = 10V>: impl TwoTerminal {
+            pins { A: 1, B: 2 }
+            spec { capacitance: C, voltage_rating: V }
+        }
+        "#,
+    )
+    .unwrap();
+
+    // Root file: references the module
+    fs::write(
+        dir.path().join("src/main.cohdl"),
+        r#"
+        module parts
+
+        design MainBoard {
+            inst c1: MLCC<C: 100nF>
+        }
+        "#,
+    )
+    .unwrap();
+
+    cohdl()
+        .args(["build", "--color", "never"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("out/test-board.net").exists());
+}
+
+#[test]
+fn build_missing_module_file_exits_1() {
+    let dir = setup_project(
+        r#"
+        module nonexistent
+
+        design MainBoard {}
+        "#,
+    );
+    cohdl()
+        .args(["build", "--color", "never"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("could not read module `nonexistent`"));
+}
+
 // ── build with custom out-dir ───────────────────────────────────────────────
 
 #[test]

--- a/crates/cohdl-parser/src/grammar.pest
+++ b/crates/cohdl-parser/src/grammar.pest
@@ -37,8 +37,8 @@ use_decl  = { "use" ~ use_path }
 use_path  = { ident ~ ("::" ~ (use_group | ident))* }
 use_group = { "{" ~ ident ~ ("," ~ ident)* ~ ","? ~ "}" }
 
-// ── Module declaration (pub mod / mod) ──────
-mod_decl = { "mod" ~ ident }
+// ── Module declaration (file-level reference) ──
+mod_decl = { "module" ~ ident ~ !"{" }
 
 // ── Identifiers & paths ────────────────────
 ident       = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }

--- a/crates/cohdl-parser/src/tests.rs
+++ b/crates/cohdl-parser/src/tests.rs
@@ -674,7 +674,7 @@ fn use_group_import() {
 
 #[test]
 fn mod_decl_basic() {
-    assert_parses!(Rule::mod_decl, "mod common");
+    assert_parses!(Rule::mod_decl, "module common");
 }
 
 // ═══════════════════════════════════════════════
@@ -1000,9 +1000,9 @@ fn file_use_and_design() {
 fn file_mod_declarations() {
     assert_parses!(
         Rule::file,
-        "pub mod stm32f1
-        pub mod stm32f4
-        mod common"
+        "pub module stm32f1
+        pub module stm32f4
+        module common"
     );
 }
 
@@ -1353,11 +1353,11 @@ fn parses_to_attribute_designator() {
 fn parses_to_mod_decl() {
     parses_to! {
         parser: CohdlParser,
-        input: "mod common",
+        input: "module common",
         rule: Rule::mod_decl,
         tokens: [
-            mod_decl(0, 10, [
-                ident(4, 10)
+            mod_decl(0, 13, [
+                ident(7, 13)
             ])
         ]
     };

--- a/crates/cohdl-parser/tests/parse_integration.rs
+++ b/crates/cohdl-parser/tests/parse_integration.rs
@@ -231,12 +231,12 @@ part mlcc_100nF_0402: MLCC<C: 100nF, V: 10V, pkg: C0402> {
     alt { mfr: "Yageo", mpn: "CC0402KRX5R9BB104" }
 }
 
-mod common
+module common
 "#;
 
     let sf = parse_source_file(src).expect("should parse module file");
 
-    // 2 use + 2 type + 1 fn + 1 part + 1 mod = 7
+    // 2 use + 2 type + 1 fn + 1 part + 1 module = 7
     assert_eq!(sf.items.len(), 7);
 
     // use power::decoupling

--- a/docs/src/cli/reference.md
+++ b/docs/src/cli/reference.md
@@ -99,7 +99,7 @@ top = "MyBoard"
 |-------------|-----------|------------------------------------------------|
 | `[package]` | `name`    | Project name (used for output file naming)     |
 | `[package]` | `version` | Project version                                |
-| `[design]`  | `root`    | Path to the root `.cohdl` source file          |
+| `[design]`  | `root`    | Path to the root `.cohdl` source file. Any `module` declarations in this file are resolved to sibling `.cohdl` files in the same directory. |
 | `[design]`  | `top`     | Name of the top-level `design` to compile      |
 
 The `--design` flag overrides the `top` field from the manifest.
@@ -109,7 +109,7 @@ The `--design` flag overrides the `top` field from the manifest.
 The compiler runs these stages in order:
 
 ```
-1. Parse        Read and parse .cohdl source files
+1. Parse        Read root file, resolve `module` declarations, parse all sources
 2. Resolve      Name resolution and symbol table construction
 3. Type check   Generic instantiation and type validation
 4. Connectivity Flatten design into instances and merged nets

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -14,7 +14,7 @@ If you plan to use the KiCad backend:
 Clone the repository and build with Cargo:
 
 ```bash
-git clone https://github.com/conol/cohdl.git
+git clone https://github.com/conol-ai/cohdl.git
 cd cohdl
 cargo build --release
 ```

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -29,10 +29,24 @@ module passives {
 Reference a module defined in a separate file:
 
 ```cohdl
-mod common
+module common
 ```
 
-This tells the compiler to look for a file named `common.cohdl` and include its contents under the `common` namespace.
+This tells the compiler to look for a file named `common.cohdl` in the same directory and include its contents. This works like Rust's `mod` keyword — the `module` declaration without braces loads the corresponding `.cohdl` file.
+
+Multiple modules can be declared:
+
+```cohdl
+module devices
+module connectors
+module passives
+
+design MainBoard {
+    inst mcu: STM32F103<pkg: "LQFP48">
+    inst c1: mlcc_100nF_0402
+    // ...
+}
+```
 
 ## Visibility
 
@@ -74,7 +88,7 @@ A module can contain any top-level item:
 - `type` aliases
 - `fn` definitions
 - `use` imports
-- `mod` references
+- `module` references (external file modules)
 - Nested `module` definitions
 
 ## Using items from modules

--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -38,15 +38,15 @@ design Board {
 }
 ```
 
-### `mod` declarations
+### `module` declarations
 
 Reference an external module defined in a separate file:
 
 ```cohdl
-mod common
+module common
 ```
 
-This imports the contents of `common.cohdl` as a module named `common`.
+This loads `common.cohdl` from the same directory and includes its contents. See [Modules](modules.md) for more details.
 
 ## Physical packages
 

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -22,7 +22,7 @@ root = "main.cohdl"
 top = "MyBoard"
 ```
 
-- `root` — the source file to compile
+- `root` — the root source file to compile (use `module` declarations inside it to include other files)
 - `top` — the name of the top-level `design` to compile
 
 ## 3. Write your first design

--- a/tests/fixtures/generic_passives/src/main.cohdl
+++ b/tests/fixtures/generic_passives/src/main.cohdl
@@ -7,6 +7,9 @@
 //   r_bot    — RES<R: 10kohm>   (voltage divider bottom)
 //   c_dec    — SmallCap   (MLCC<C: 100nF>)
 
+module lib
+module power
+
 design TestBoard {
     inst c1: SmallCap47
     inst r1: PullupRes

--- a/tests/fixtures/multi_module/src/main.cohdl
+++ b/tests/fixtures/multi_module/src/main.cohdl
@@ -1,6 +1,8 @@
 // Board design: uses public items from sensors and power modules.
 // Deliberately attempts to access private items to trigger sema errors.
 
+module lib
+
 use sensors::TempSensor
 use power::ldo
 

--- a/tests/fixtures/stm32_minimal/src/main.cohdl
+++ b/tests/fixtures/stm32_minimal/src/main.cohdl
@@ -1,5 +1,9 @@
 // MainBoard design: STM32F103C8T6 + USB Type-C + 4x decoupling caps.
 
+module devices
+module connectors
+module passives
+
 design MainBoard {
     inst mcu: STM32F103<pkg: "LQFP48">
     inst usb: USB_TypeC_Receptacle


### PR DESCRIPTION
## Summary

This PR implements module resolution for CoHDL projects, allowing developers to split designs across multiple files using `module` declarations. When a root source file contains `module <name>` declarations, the compiler automatically loads and prepends the corresponding `<name>.cohdl` files from the same directory before compilation.

## Key Changes

- **Module Resolution Logic**: Added `resolve_modules()` function that:
  - Parses the root source file to find `ModDecl` nodes
  - Loads each referenced module file from the same directory
  - Combines module contents before the root source (similar to Rust's `mod` behavior)
  - Gracefully handles parse errors by returning root source as-is for the pipeline to report

- **Grammar Update**: Changed `mod_decl` rule from `"mod" ~ ident` to `"module" ~ ident ~ !"{"`
  - Uses keyword `module` instead of `mod` for external file references
  - Negative lookahead `!"{}"` prevents matching inline module definitions

- **CLI Integration**: Updated both `cmd_build()` and `cmd_check()` to:
  - Read root source file separately
  - Call `resolve_modules()` to combine with module files
  - Report module loading errors with file paths and context

- **Documentation**: Updated docs to clarify:
  - `module` declarations load external `.cohdl` files (like Rust's `mod`)
  - Multiple modules can be declared in a single file
  - Module files are resolved from the same directory as the root file

- **Tests**: Added integration tests for:
  - Multi-file projects with module declarations
  - Error handling for missing module files

- **Fixtures**: Updated test fixtures to use `module` declarations for multi-file designs

- **Minor Fixes**: 
  - Fixed repository URL in installation docs
  - Added `out/` to `.gitignore`
  - Imported `Path` type for directory operations

https://claude.ai/code/session_018nK4rQSgufbirACiX8y91d