### PR TITLE
Add footprint override support via device spec and instance attribute

### DIFF
--- a/crates/cohdl-cli/src/main.rs
+++ b/crates/cohdl-cli/src/main.rs
@@ -217,12 +217,10 @@ fn resolve_bundled_std() -> Result<String, String> {
     let source_file = parse_source_file(STD_LIB_COHDL)
         .map_err(|e| format!("failed to parse std/src/lib.cohdl: {:?}", e))?;
 
-    let embedded_sources: std::collections::HashMap<&str, &str> = [
-        ("traits", STD_TRAITS_COHDL),
-        ("passive", STD_PASSIVE_COHDL),
-    ]
-    .into_iter()
-    .collect();
+    let embedded_sources: std::collections::HashMap<&str, &str> =
+        [("traits", STD_TRAITS_COHDL), ("passive", STD_PASSIVE_COHDL)]
+            .into_iter()
+            .collect();
 
     let mut inner = String::new();
     for item in &source_file.items {
@@ -263,10 +261,8 @@ fn resolve_path_dependency(name: &str, dep_path: &str) -> Result<String, String>
             e
         )
     })?;
-    let manifest: CohdlManifest =
-        toml::from_str(&manifest_content).map_err(|e| {
-            format!("invalid cohdl.toml for dependency `{}`: {}", name, e)
-        })?;
+    let manifest: CohdlManifest = toml::from_str(&manifest_content)
+        .map_err(|e| format!("invalid cohdl.toml for dependency `{}`: {}", name, e))?;
 
     let root_path = dep_dir.join(&manifest.design.root);
     let root_src = fs::read_to_string(&root_path).map_err(|e| {
@@ -649,7 +645,10 @@ fn cmd_build(
         }
     };
 
-    let top_design = match design_override.as_deref().or(manifest.design.top.as_deref()) {
+    let top_design = match design_override
+        .as_deref()
+        .or(manifest.design.top.as_deref())
+    {
         Some(t) => t,
         None => {
             stderr

--- a/crates/cohdl-codegen-kicad/src/bom.rs
+++ b/crates/cohdl-codegen-kicad/src/bom.rs
@@ -97,6 +97,7 @@ mod tests {
             mpn: mpn.map(|s| s.into()),
             alt_mpns: alt_mpns.iter().map(|s| s.to_string()).collect(),
             generic_substitutions: HashMap::new(),
+            footprint_override: None,
         }
     }
 

--- a/crates/cohdl-codegen-kicad/src/lib.rs
+++ b/crates/cohdl-codegen-kicad/src/lib.rs
@@ -69,7 +69,10 @@ pub fn emit_kicad_netlist_with_config(ir: &ConnectivityIR, config: &KicadNetlist
     // ── Components
     writeln!(out, "  (components").unwrap();
     for inst in &ir.instances {
-        let footprint = resolve_footprint(&inst.device, config);
+        let footprint = inst
+            .footprint_override
+            .clone()
+            .unwrap_or_else(|| resolve_footprint(&inst.device, config));
         let value = inst
             .generic_substitutions
             .get("value")
@@ -198,6 +201,7 @@ mod tests {
                         m.insert("value".to_string(), "STM32F103".to_string());
                         m
                     },
+                    footprint_override: None,
                 },
                 Instance {
                     id: InstanceId(1),
@@ -211,6 +215,7 @@ mod tests {
                         m.insert("value".to_string(), "10k".to_string());
                         m
                     },
+                    footprint_override: None,
                 },
                 Instance {
                     id: InstanceId(2),
@@ -224,6 +229,7 @@ mod tests {
                         m.insert("value".to_string(), "100nF".to_string());
                         m
                     },
+                    footprint_override: None,
                 },
             ],
             nets: vec![
@@ -370,6 +376,7 @@ mod tests {
                 mpn: None,
                 alt_mpns: vec![],
                 generic_substitutions: HashMap::new(),
+                footprint_override: None,
             }],
             nets: vec![],
         };
@@ -388,6 +395,7 @@ mod tests {
                 mpn: None,
                 alt_mpns: vec![],
                 generic_substitutions: HashMap::new(),
+                footprint_override: None,
             }],
             nets: vec![],
         };
@@ -431,11 +439,52 @@ mod tests {
                     m.insert("value".to_string(), "R<10>".to_string());
                     m
                 },
+                footprint_override: None,
             }],
             nets: vec![],
         };
         let netlist = emit_kicad_netlist(&ir);
         assert!(netlist.contains("R&lt;10&gt;"));
         assert!(netlist.contains("Part&lt;1&gt;&amp;&quot;2&quot;"));
+    }
+
+    #[test]
+    fn footprint_override_takes_precedence() {
+        let ir = ConnectivityIR {
+            instances: vec![Instance {
+                id: InstanceId(0),
+                name: "U1".into(),
+                hierarchical_path: "Board::U1".into(),
+                device: "LQFP48".into(),
+                mpn: None,
+                alt_mpns: vec![],
+                generic_substitutions: HashMap::new(),
+                footprint_override: Some("Custom:LQFP-48_Custom".into()),
+            }],
+            nets: vec![],
+        };
+        let netlist = emit_kicad_netlist(&ir);
+        // Should use the override, not the table lookup.
+        assert!(netlist.contains(r#"(footprint "Custom:LQFP-48_Custom")"#));
+        assert!(!netlist.contains("Package_QFP:LQFP-48_7x7mm_P0.5mm"));
+    }
+
+    #[test]
+    fn footprint_override_none_falls_back_to_table() {
+        let ir = ConnectivityIR {
+            instances: vec![Instance {
+                id: InstanceId(0),
+                name: "U1".into(),
+                hierarchical_path: "Board::U1".into(),
+                device: "LQFP48".into(),
+                mpn: None,
+                alt_mpns: vec![],
+                generic_substitutions: HashMap::new(),
+                footprint_override: None,
+            }],
+            nets: vec![],
+        };
+        let netlist = emit_kicad_netlist(&ir);
+        assert!(netlist.contains(r#"(footprint "Package_QFP:LQFP-48_7x7mm_P0.5mm")"#));
     }
 }

--- a/crates/cohdl-codegen-kicad/src/lib.rs
+++ b/crates/cohdl-codegen-kicad/src/lib.rs
@@ -101,11 +101,7 @@ pub fn emit_kicad_netlist_with_config(ir: &ConnectivityIR, config: &KicadNetlist
             )
             .unwrap();
         }
-        writeln!(
-            out,
-            "      (sheetpath (names \"/\") (tstamps \"/\"))"
-        )
-        .unwrap();
+        writeln!(out, "      (sheetpath (names \"/\") (tstamps \"/\"))").unwrap();
         writeln!(out, "      (tstamp \"{:08X}\")", inst.id.0).unwrap();
         writeln!(out, "    )").unwrap();
     }

--- a/crates/cohdl-codegen-lceda/src/lib.rs
+++ b/crates/cohdl-codegen-lceda/src/lib.rs
@@ -134,7 +134,11 @@ fn build_component(
     set(&mut props, "Name", &value);
     set(&mut props, "Unique ID", unique_id);
     set(&mut props, "DeviceName", &inst.device);
-    set(&mut props, "FootprintName", &inst.device);
+    let footprint_name = inst
+        .footprint_override
+        .as_deref()
+        .unwrap_or(&inst.device);
+    set(&mut props, "FootprintName", footprint_name);
 
     // Populate MPN-related fields if available.
     if let Some(mpn) = &inst.mpn {
@@ -207,6 +211,7 @@ mod tests {
                         m.insert("value".to_string(), "STM32F103".to_string());
                         m
                     },
+                    footprint_override: None,
                 },
                 Instance {
                     id: InstanceId(1),
@@ -221,6 +226,7 @@ mod tests {
                         m.insert("lcsc".to_string(), "C1525".to_string());
                         m
                     },
+                    footprint_override: None,
                 },
             ],
             nets: vec![
@@ -368,5 +374,51 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed["version"], "2.0.0");
         assert_eq!(parsed["components"].as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn footprint_override_used_when_present() {
+        let ir = ConnectivityIR {
+            instances: vec![Instance {
+                id: InstanceId(0),
+                name: "U1".into(),
+                hierarchical_path: "Board::U1".into(),
+                device: "LQFP48".into(),
+                mpn: None,
+                alt_mpns: vec![],
+                generic_substitutions: HashMap::new(),
+                footprint_override: Some("LQFP-48_Custom".into()),
+            }],
+            nets: vec![],
+        };
+        let output = emit_lceda_netlist(&ir);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(
+            parsed["components"]["gge1"]["props"]["FootprintName"],
+            "LQFP-48_Custom"
+        );
+    }
+
+    #[test]
+    fn footprint_falls_back_to_device_when_no_override() {
+        let ir = ConnectivityIR {
+            instances: vec![Instance {
+                id: InstanceId(0),
+                name: "U1".into(),
+                hierarchical_path: "Board::U1".into(),
+                device: "LQFP48".into(),
+                mpn: None,
+                alt_mpns: vec![],
+                generic_substitutions: HashMap::new(),
+                footprint_override: None,
+            }],
+            nets: vec![],
+        };
+        let output = emit_lceda_netlist(&ir);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(
+            parsed["components"]["gge1"]["props"]["FootprintName"],
+            "LQFP48"
+        );
     }
 }

--- a/crates/cohdl-codegen-lceda/src/lib.rs
+++ b/crates/cohdl-codegen-lceda/src/lib.rs
@@ -77,10 +77,7 @@ pub fn emit_lceda_netlist(ir: &ConnectivityIR) -> String {
     // Collect all unique net names for designRule.netRule.
     let mut net_rule = serde_json::Map::new();
     for net in &ir.nets {
-        let has_internal_pin = net
-            .pins
-            .iter()
-            .any(|p| p.instance_id != EXTERNAL_INSTANCE);
+        let has_internal_pin = net.pins.iter().any(|p| p.instance_id != EXTERNAL_INSTANCE);
         if !has_internal_pin {
             continue;
         }
@@ -134,10 +131,7 @@ fn build_component(
     set(&mut props, "Name", &value);
     set(&mut props, "Unique ID", unique_id);
     set(&mut props, "DeviceName", &inst.device);
-    let footprint_name = inst
-        .footprint_override
-        .as_deref()
-        .unwrap_or(&inst.device);
+    let footprint_name = inst.footprint_override.as_deref().unwrap_or(&inst.device);
     set(&mut props, "FootprintName", footprint_name);
 
     // Populate MPN-related fields if available.
@@ -171,10 +165,7 @@ fn build_component(
                 net: net_name.to_string(),
                 props: {
                     let mut m = serde_json::Map::new();
-                    m.insert(
-                        "Pin Number".into(),
-                        serde_json::Value::String(num.clone()),
-                    );
+                    m.insert("Pin Number".into(), serde_json::Value::String(num.clone()));
                     m
                 },
             };
@@ -314,10 +305,7 @@ mod tests {
             parsed["components"]["gge2"]["props"]["Supplier Part"],
             "C1525"
         );
-        assert_eq!(
-            parsed["components"]["gge2"]["props"]["Supplier"],
-            "LCSC"
-        );
+        assert_eq!(parsed["components"]["gge2"]["props"]["Supplier"], "LCSC");
     }
 
     #[test]

--- a/crates/cohdl-drc/src/tests.rs
+++ b/crates/cohdl-drc/src/tests.rs
@@ -21,6 +21,7 @@ fn inst(id: u32, name: &str, device: &str, subs: &[(&str, &str)]) -> Instance {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect(),
+        footprint_override: None,
     }
 }
 

--- a/crates/cohdl-lsp/src/lib.rs
+++ b/crates/cohdl-lsp/src/lib.rs
@@ -91,19 +91,21 @@ fn synthesize_std() -> String {
         Err(_) => return String::new(),
     };
 
-    let embedded: HashMap<&str, &str> = [
-        ("traits", STD_TRAITS_COHDL),
-        ("passive", STD_PASSIVE_COHDL),
-    ]
-    .into_iter()
-    .collect();
+    let embedded: HashMap<&str, &str> =
+        [("traits", STD_TRAITS_COHDL), ("passive", STD_PASSIVE_COHDL)]
+            .into_iter()
+            .collect();
 
     let mut inner = String::new();
     for item in &source_file.items {
         if let TopLevelItemKind::Mod(m) = &item.kind {
             let name = &m.name.name;
             if let Some(content) = embedded.get(name.as_str()) {
-                let vis = if item.visibility.is_some() { "pub " } else { "" };
+                let vis = if item.visibility.is_some() {
+                    "pub "
+                } else {
+                    ""
+                };
                 inner.push_str(&format!("{}module {} {{\n{}\n}}\n", vis, name, content));
             }
         }

--- a/crates/cohdl-sema/src/connectivity.rs
+++ b/crates/cohdl-sema/src/connectivity.rs
@@ -54,6 +54,8 @@ pub struct Instance {
     pub alt_mpns: Vec<String>,
     /// Generic parameter substitutions.
     pub generic_substitutions: HashMap<String, String>,
+    /// Footprint override from `#[footprint("...")]` attribute or device spec.
+    pub footprint_override: Option<String>,
 }
 
 /// The connectivity IR: a flat list of instances and merged nets.
@@ -141,6 +143,7 @@ pub fn build_connectivity(
             mpn: ci.mpn.clone(),
             alt_mpns: ci.alt_mpns.clone(),
             generic_substitutions: ci.generic_substitutions.clone(),
+            footprint_override: ci.footprint_override.clone(),
         })
         .collect();
 
@@ -366,6 +369,7 @@ mod tests {
             alt_mpns: Vec::new(),
             generic_substitutions: HashMap::new(),
             designator_override: None,
+            footprint_override: None,
             impl_traits: Vec::new(),
         }
     }
@@ -645,6 +649,7 @@ mod tests {
                 alt_mpns: Vec::new(),
                 generic_substitutions: subs.clone(),
                 designator_override: None,
+                footprint_override: None,
                 impl_traits: Vec::new(),
             }],
             nets: vec![],

--- a/crates/cohdl-sema/src/designator.rs
+++ b/crates/cohdl-sema/src/designator.rs
@@ -563,6 +563,7 @@ mod tests {
                     mpn: None,
                     alt_mpns: vec![],
                     generic_substitutions: HashMap::new(),
+                    footprint_override: None,
                 },
                 Instance {
                     id: InstanceId(1),
@@ -572,6 +573,7 @@ mod tests {
                     mpn: None,
                     alt_mpns: vec![],
                     generic_substitutions: HashMap::new(),
+                    footprint_override: None,
                 },
             ],
             nets: vec![],

--- a/crates/cohdl-sema/src/typeck.rs
+++ b/crates/cohdl-sema/src/typeck.rs
@@ -96,6 +96,8 @@ pub struct ComponentInstance {
     pub generic_substitutions: HashMap<std::string::String, std::string::String>,
     /// Explicit designator override from `#[designator("U1")]`.
     pub designator_override: Option<std::string::String>,
+    /// Footprint override from `#[footprint("...")]` attribute or device spec.
+    pub footprint_override: Option<std::string::String>,
     /// Traits the underlying device implements (used for prefix derivation).
     pub impl_traits: Vec<std::string::String>,
 }
@@ -155,6 +157,8 @@ struct DeviceDef {
     declared_pins: HashSet<std::string::String>,
     /// Spec fields declared by this device: (name, kind).
     declared_specs: Vec<(std::string::String, ValueKind)>,
+    /// Footprint string from `spec { footprint: "..." }`, if present.
+    footprint: Option<std::string::String>,
 }
 
 /// A collected generic parameter definition.
@@ -320,6 +324,25 @@ impl TypeChecker {
             }
         }
 
+        // Extract footprint from spec block if present.
+        let footprint = d.body.iter().find_map(|item| {
+            if let DeviceBodyItem::Spec(spec) = item {
+                spec.entries.iter().find_map(|e| {
+                    if e.name.name == "footprint" {
+                        if let ExprKind::String(ref s) = e.value.kind {
+                            Some(s.value.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        });
+
         self.devices.insert(
             qname.clone(),
             DeviceDef {
@@ -328,6 +351,7 @@ impl TypeChecker {
                 impl_traits,
                 declared_pins,
                 declared_specs,
+                footprint,
             },
         );
     }
@@ -695,6 +719,25 @@ impl TypeChecker {
                     }
                 });
 
+                // Extract #[footprint("...")] from statement attributes.
+                let footprint_attr = stmt.attributes.iter().find_map(|attr| {
+                    if attr.name.name == "footprint" {
+                        if let Some(ast::AttributeArgs::Strings(ref strings)) = attr.args {
+                            strings.first().map(|s| s.value.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                });
+
+                // Footprint priority: #[footprint()] attribute > device spec > None.
+                let footprint_override = footprint_attr.or_else(|| {
+                    self.find_device(&final_device, module_path)
+                        .and_then(|dev| dev.footprint.clone())
+                });
+
                 // Look up the device's impl_traits.
                 let impl_traits = self
                     .find_device(&final_device, module_path)
@@ -711,6 +754,7 @@ impl TypeChecker {
                     alt_mpns,
                     generic_substitutions: all_args,
                     designator_override,
+                    footprint_override,
                     impl_traits,
                 });
             }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -87,8 +87,10 @@ fn run_pipeline(src: &str) -> PipelineOutput {
 /// Synthesize the bundled `std` dependency source by wrapping the std source
 /// files into `module std { pub module traits { ... } pub module passive { ... } }`.
 fn synthesize_std_source() -> String {
-    let traits_src = std::fs::read_to_string("std/src/traits.cohdl").expect("cannot read std/src/traits.cohdl");
-    let passive_src = std::fs::read_to_string("std/src/passive.cohdl").expect("cannot read std/src/passive.cohdl");
+    let traits_src =
+        std::fs::read_to_string("std/src/traits.cohdl").expect("cannot read std/src/traits.cohdl");
+    let passive_src = std::fs::read_to_string("std/src/passive.cohdl")
+        .expect("cannot read std/src/passive.cohdl");
 
     format!(
         "module std {{\npub module traits {{\n{}\n}}\npub module passive {{\n{}\n}}\n}}\n",


### PR DESCRIPTION
Footprint can now be specified in two ways, with clear priority:
1. #[footprint("...")] attribute on inst statements (highest priority)
2. footprint field in device spec block
3. Existing table lookup / device name passthrough (fallback)

This flows through DeviceDef → ComponentInstance → ConnectivityIR Instance
and is consumed by both KiCad and LCEDA netlist emitters.

https://claude.ai/code/session_0154ABtufxcmUVLSyVPPnbqA