### PR TITLE
fix(subdesign): close the five RFC-032 audit findings

### DIFF
--- a/examples/joint-motor-controller/cohdl.lock
+++ b/examples/joint-motor-controller/cohdl.lock
@@ -13,7 +13,7 @@ hash = "sha256:997b238b4ea7097e976b03c3ceebbf59100febd12be15e3fe7c5ed407d99da76"
 [[package]]
 name = "can"
 version = "0.1.0"
-hash = "sha256:b620cbebe884a372ea806d2a2df7a43f6af0418a6eaf4316937aae5b5819ef48"
+hash = "sha256:7b5cbdab944f62fa1e222257b76f7c4e80f5a2593d020849acd61ad81381b4dd"
 
 [[package]]
 name = "connectors"
@@ -43,7 +43,7 @@ hash = "sha256:e54a7d8b49abf495644d31f2b1f4da83eeebbac3bada3d1392643789b44dcf73"
 [[package]]
 name = "motor-driver"
 version = "0.1.0"
-hash = "sha256:8e780fc574c654b1585f72ea5342bc13bd69f197474bd1e4feffc63127e168ba"
+hash = "sha256:420c332614891fa13dc6c5f8382771b78037ee87473f2173f7a7b3b299ed2e96"
 
 [[package]]
 name = "osc"

--- a/src/check/bodies.rs
+++ b/src/check/bodies.rs
@@ -147,7 +147,7 @@ fn check_one(world: &World, f: &FnDef, allow_sub_use: bool, diags: &mut Diagnost
                     ));
                     continue;
                 }
-                check_sub_use_site(world, sub, diags);
+                check_sub_use_site(world, f, sub, diags);
                 check_named_generic_args(world, f, &sub.ty.generic_args, diags);
                 for conn in &sub.conns {
                     // A bare name may be a net (resolved at expansion); only
@@ -307,12 +307,18 @@ fn check_device_generic_args(
 }
 
 /// RFC-032: the statically-knowable properties of a NESTED use site — target
-/// kind, variant selector, generic arity + concrete unit literals, and
-/// connection port keys. A use site inside an unused subdesign otherwise
-/// escapes all of this until a consumer instantiates the enclosing one.
-/// Messages mirror expansion's exactly so a used enclosing subdesign
-/// reported by both collapses under dedup.
-fn check_sub_use_site(world: &World, stmt: &crate::ast::SubdesignUseStmt, diags: &mut Diagnostics) {
+/// kind, variant selector, generic arity, argument kinds and concrete
+/// values/bounds, and connection port keys. A use site inside an unused
+/// subdesign otherwise escapes all of this until a consumer instantiates
+/// the enclosing one. Judgments come from THE bound checker (`resolve_one`,
+/// DR-016) so messages mirror expansion's exactly and a used enclosing
+/// subdesign reported by both collapses under dedup.
+fn check_sub_use_site(
+    world: &World,
+    f: &FnDef,
+    stmt: &crate::ast::SubdesignUseStmt,
+    diags: &mut Diagnostics,
+) {
     let name = &stmt.ty.name;
     let Some(sd) = world.subdesigns.get(&name.name) else {
         if let Some(sym) = world.symbols.get(&name.name) {
@@ -352,34 +358,30 @@ fn check_sub_use_site(world: &World, stmt: &crate::ast::SubdesignUseStmt, diags:
             ),
         ));
     }
+    let enclosing: BTreeSet<&str> = f.generics.iter().map(|g| g.name.name.as_str()).collect();
     for (i, param) in sd.generics.iter().enumerate() {
         match args.get(i) {
-            // Only a concrete unit literal is judged here; a name argument
-            // may reference an enclosing generic, resolvable only per use.
-            Some(GenericArg::Unit(v, span)) => {
-                if let GenericBound::Unit(u) = &param.bound {
-                    if v.unit != u.unit {
-                        diags.push(
-                            Diagnostic::error(
-                                "E112",
-                                *span,
-                                format!(
-                                    "generic argument for `{}` has the wrong unit type: expected `{}`, found `{}`",
-                                    param.name.name,
-                                    u.unit.type_name(),
-                                    v.unit.type_name()
-                                ),
-                            )
-                            .with_primary_label(format!(
-                                "`{}` is a `{}`",
-                                v.text,
-                                v.unit.type_name()
-                            )),
-                        );
-                    }
+            Some(arg) => {
+                // Deferred to expansion: a name referencing an ENCLOSING
+                // generic (its value exists only per use, RFC-006) or an
+                // unknown name (check_named_generic_args' E202 above owns
+                // that report). Everything else — unit literals, bare
+                // numbers, concrete device/part names — is judged now with
+                // an empty substitution, which for these argument shapes
+                // behaves exactly as expansion's env does.
+                let deferred = matches!(arg, GenericArg::Name(id)
+                    if enclosing.contains(id.name.as_str())
+                        || !world.symbols.contains_key(&id.name));
+                if !deferred {
+                    let _ = crate::check::generics::resolve_one(
+                        world,
+                        param,
+                        arg,
+                        &crate::check::generics::Substitution::new(),
+                        diags,
+                    );
                 }
             }
-            Some(_) => {}
             None => {
                 if param.default.is_none() {
                     diags.push(

--- a/src/check/bodies.rs
+++ b/src/check/bodies.rs
@@ -147,6 +147,7 @@ fn check_one(world: &World, f: &FnDef, allow_sub_use: bool, diags: &mut Diagnost
                     ));
                     continue;
                 }
+                check_sub_use_site(world, sub, diags);
                 check_named_generic_args(world, f, &sub.ty.generic_args, diags);
                 for conn in &sub.conns {
                     // A bare name may be a net (resolved at expansion); only
@@ -301,6 +302,133 @@ fn check_device_generic_args(
                     ),
                 ));
             }
+        }
+    }
+}
+
+/// RFC-032: the statically-knowable properties of a NESTED use site — target
+/// kind, variant selector, generic arity + concrete unit literals, and
+/// connection port keys. A use site inside an unused subdesign otherwise
+/// escapes all of this until a consumer instantiates the enclosing one.
+/// Messages mirror expansion's exactly so a used enclosing subdesign
+/// reported by both collapses under dedup.
+fn check_sub_use_site(world: &World, stmt: &crate::ast::SubdesignUseStmt, diags: &mut Diagnostics) {
+    let name = &stmt.ty.name;
+    let Some(sd) = world.subdesigns.get(&name.name) else {
+        if let Some(sym) = world.symbols.get(&name.name) {
+            diags.push(Diagnostic::error(
+                "E205",
+                name.span,
+                format!(
+                    "`{}` is a {} — a `subdesign` use site requires a subdesign",
+                    name.name, sym.kind
+                ),
+            ));
+        }
+        return;
+    };
+    if let Some(sel) = &stmt.ty.variant {
+        diags.push(Diagnostic::error(
+            "E1303",
+            sel.span,
+            format!(
+                "a subdesign has no variants — remove the `[{}]` selector",
+                sel.name
+            ),
+        ));
+    }
+    let args = &stmt.ty.generic_args;
+    if args.len() > sd.generics.len() {
+        diags.push(Diagnostic::error(
+            "E401",
+            stmt.ty.span,
+            format!(
+                "subdesign `{}` takes {} generic argument{}, but {} {} given",
+                short(&name.name),
+                sd.generics.len(),
+                if sd.generics.len() == 1 { "" } else { "s" },
+                args.len(),
+                if args.len() == 1 { "was" } else { "were" }
+            ),
+        ));
+    }
+    for (i, param) in sd.generics.iter().enumerate() {
+        match args.get(i) {
+            // Only a concrete unit literal is judged here; a name argument
+            // may reference an enclosing generic, resolvable only per use.
+            Some(GenericArg::Unit(v, span)) => {
+                if let GenericBound::Unit(u) = &param.bound {
+                    if v.unit != u.unit {
+                        diags.push(
+                            Diagnostic::error(
+                                "E112",
+                                *span,
+                                format!(
+                                    "generic argument for `{}` has the wrong unit type: expected `{}`, found `{}`",
+                                    param.name.name,
+                                    u.unit.type_name(),
+                                    v.unit.type_name()
+                                ),
+                            )
+                            .with_primary_label(format!(
+                                "`{}` is a `{}`",
+                                v.text,
+                                v.unit.type_name()
+                            )),
+                        );
+                    }
+                }
+            }
+            Some(_) => {}
+            None => {
+                if param.default.is_none() {
+                    diags.push(
+                        Diagnostic::error(
+                            "E401",
+                            stmt.ty.span,
+                            format!(
+                                "missing generic argument for `{}` of subdesign `{}` (it has no default)",
+                                param.name.name,
+                                short(&name.name)
+                            ),
+                        )
+                        .with_help(crate::check::generics::describe_param(param)),
+                    );
+                }
+            }
+        }
+    }
+    let ports: BTreeSet<&str> = sd.ports.iter().map(|p| p.name.name.as_str()).collect();
+    let mut seen: BTreeMap<&str, crate::span::Span> = BTreeMap::new();
+    for conn in &stmt.conns {
+        if let Some(prev) = seen.insert(conn.port.name.as_str(), conn.span) {
+            diags.push(
+                Diagnostic::error(
+                    "E1301",
+                    conn.port.span,
+                    format!("port `{}` is connected more than once", conn.port.name),
+                )
+                .with_secondary(prev, "first connected here".to_string()),
+            );
+            continue;
+        }
+        if !ports.contains(conn.port.name.as_str()) {
+            diags.push(
+                Diagnostic::error(
+                    "E1301",
+                    conn.port.span,
+                    format!(
+                        "subdesign `{}` (use site `{}`) has no port named `{}`",
+                        short(&name.name),
+                        stmt.name.name,
+                        conn.port.name
+                    ),
+                )
+                .with_help(format!(
+                    "its ports are: {}",
+                    ports.iter().cloned().collect::<Vec<_>>().join(", ")
+                )),
+            );
         }
     }
 }

--- a/src/check/expand.rs
+++ b/src/check/expand.rs
@@ -256,6 +256,8 @@ impl<'w, 'd> Expander<'w, 'd> {
                     Some((n, span)) => {
                         if scope.arrays.contains_key(&inst.name.name)
                             || scope.local_insts.contains_key(&inst.name.name)
+                            || scope.local_subs.contains_key(&inst.name.name)
+                            || scope.bindings.contains_key(&inst.name.name)
                         {
                             self.diags.push(Diagnostic::error(
                                 "E201",
@@ -733,41 +735,79 @@ impl<'w, 'd> Expander<'w, 'd> {
         // RFC-028: an instance argument may be a local inst OR a fn's
         // Instance-typed parameter — the same two forms every other instance
         // reference already resolves through.
-        let resolve_inst =
-            |ex: &mut Self, id: &Ident, index: Option<(i64, Span)>| -> Option<String> {
-                // RFC-024: `NAME[i]` resolves through the SAME element resolver
-                // `place` uses, so the two can never disagree about which element
-                // an index names. An unindexed name keeps its old meaning.
-                if index.is_some() || scope.arrays.contains_key(&id.name) {
-                    let local = ex.indexed_local(
-                        id,
-                        index,
-                        scope,
-                        &format!(
-                            "`{}` is array-typed — name one element, e.g. `{}[0]`",
-                            id.name, id.name
-                        ),
-                    )?;
-                    if let Some(p) = scope.local_insts.get(&local) {
-                        return Some(p.clone());
-                    }
-                }
-                if let Some(p) = scope.local_insts.get(&id.name) {
+        let resolve_inst = |ex: &mut Self,
+                            id: &Ident,
+                            index: Option<(i64, Span)>|
+         -> Option<String> {
+            // RFC-024: `NAME[i]` resolves through the SAME element resolver
+            // `place` uses, so the two can never disagree about which element
+            // an index names. An unindexed name keeps its old meaning.
+            if index.is_some() || scope.arrays.contains_key(&id.name) {
+                let local = ex.indexed_local(
+                    id,
+                    index,
+                    scope,
+                    &format!(
+                        "`{}` is array-typed — name one element, e.g. `{}[0]`",
+                        id.name, id.name
+                    ),
+                )?;
+                if let Some(p) = scope.local_insts.get(&local) {
                     return Some(p.clone());
                 }
-                if let Some(Binding::Instance { path, .. }) = scope.bindings.get(&id.name) {
-                    return Some(path.clone());
-                }
+            }
+            if let Some(p) = scope.local_insts.get(&id.name) {
+                return Some(p.clone());
+            }
+            if let Some(Binding::Instance { path, .. }) = scope.bindings.get(&id.name) {
+                return Some(path.clone());
+            }
+            // RFC-032: a subdesign node is never a physics target — its
+            // real components are behind the port boundary.
+            if scope.local_subs.contains_key(&id.name) {
                 ex.diags.push(Diagnostic::error(
-                    "E1009",
-                    id.span,
-                    format!("`{}` is not an instance in this scope", id.name),
-                ));
-                None
-            };
+                        "E1009",
+                        id.span,
+                        format!(
+                            "`{}` is a subdesign — a physics attribute needs a real instance; attach it inside the subdesign that owns the part (RFC-032)",
+                            id.name
+                        ),
+                    ));
+                return None;
+            }
+            ex.diags.push(Diagnostic::error(
+                "E1009",
+                id.span,
+                format!("`{}` is not an instance in this scope", id.name),
+            ));
+            None
+        };
         // The referenced instance's device pin, by NAME -> its pad numbers.
         let pin_pads = |ex: &mut Self, path: &str, pin: &Ident| -> Option<Vec<String>> {
-            let target = &ex.instances[path];
+            // RFC-032: a `Binding::Pin` may carry a subdesign PORT — a
+            // logical junction with no physical pads. A physics fact needs a
+            // real device pin, so say that precisely (never index-panic on
+            // the deliberately-absent node path).
+            let Some(target) = ex.instances.get(path) else {
+                let what = if ex.sub_nodes.contains_key(path) {
+                    format!(
+                        "`{}` resolves to a port of subdesign use site `{}`",
+                        pin.name,
+                        crate::resolve::short(path)
+                    )
+                } else {
+                    format!("`{}` does not resolve to a physical pin", pin.name)
+                };
+                ex.diags.push(Diagnostic::error(
+                    "E1009",
+                    pin.span,
+                    format!(
+                        "{} — a physics attribute needs a real device pin; attach it inside the subdesign that owns the pin (RFC-032)",
+                        what
+                    ),
+                ));
+                return None;
+            };
             let dev = ex.world.devices.get(&target.device)?;
             let variant = target.variant.clone();
             match dev
@@ -1946,6 +1986,21 @@ impl<'w, 'd> Expander<'w, 'd> {
         let body = sd.body.clone();
         let fq = ty_name.name.clone();
         for elem in element_names {
+            // RFC-024 discipline: each element is fully real, so its
+            // generated name takes the SAME duplicate check a hand-written
+            // declaration would (physical arrays get this via handle_inst).
+            if scope.local_insts.contains_key(&elem)
+                || scope.bindings.contains_key(&elem)
+                || scope.local_subs.contains_key(&elem)
+                || scope.arrays.contains_key(&elem)
+            {
+                self.diags.push(Diagnostic::error(
+                    "E201",
+                    stmt.name.span,
+                    format!("`{}` is already defined in this scope", elem),
+                ));
+                continue;
+            }
             let node_path = format!("{}::{}", scope.path, elem);
             scope.local_subs.insert(elem, node_path.clone());
             // Inside the body, every port is a pin OF THE NODE — the same
@@ -1970,19 +2025,30 @@ impl<'w, 'd> Expander<'w, 'd> {
                 arrays: BTreeMap::new(),
             };
             self.active_subs.push(fq.clone());
-            self.walk_body(&body, &mut inner);
-            self.active_subs.pop();
+            // The node exists BEFORE its body walks: an in-body reference
+            // that lands on the node path (a port used as a physics target,
+            // say) must identify it as a subdesign node, not fall through to
+            // a generic "not physical" shape. Children fill in after.
             self.sub_nodes.insert(
-                node_path,
+                node_path.clone(),
                 SubNode {
                     fq: fq.clone(),
                     use_span: stmt.span,
                     ports: ports.clone(),
-                    children_insts: inner.local_insts,
-                    children_subs: inner.local_subs,
-                    children_arrays: inner.arrays,
+                    children_insts: BTreeMap::new(),
+                    children_subs: BTreeMap::new(),
+                    children_arrays: BTreeMap::new(),
                 },
             );
+            self.walk_body(&body, &mut inner);
+            self.active_subs.pop();
+            let node = self
+                .sub_nodes
+                .get_mut(&node_path)
+                .expect("stub inserted above");
+            node.children_insts = inner.local_insts;
+            node.children_subs = inner.local_subs;
+            node.children_arrays = inner.arrays;
         }
     }
 
@@ -2366,9 +2432,15 @@ impl<'w, 'd> Expander<'w, 'd> {
                     anchors.insert(np.clone(), d.clone());
                     continue;
                 }
+                // Only an entry whose owner IS anchored can place this
+                // node; an entry in an unanchored ancestor's layout is inert
+                // and must not shadow a usable one further in (owners are
+                // strict ancestors, already final in this depth-sorted walk).
                 let mut best: Option<(usize, usize)> = None;
                 for (i, r) in self.rel_places.iter().enumerate() {
-                    if matches!(&r.target, PlaceTarget::Node(p) if p == np) {
+                    if matches!(&r.target, PlaceTarget::Node(p) if p == np)
+                        && anchors.contains_key(&r.owner)
+                    {
                         let key = (depth(&r.owner), i);
                         if best.is_none_or(|b| key < b) {
                             best = Some(key);
@@ -2377,15 +2449,16 @@ impl<'w, 'd> Expander<'w, 'd> {
                 }
                 if let Some((_, i)) = best {
                     let r = &self.rel_places[i];
-                    if let Some(pa) = anchors.get(&r.owner) {
-                        let composed = compose_place(pa, &r.data);
-                        anchors.insert(np.clone(), composed);
-                    }
+                    let composed = compose_place(&anchors[&r.owner], &r.data);
+                    anchors.insert(np.clone(), composed);
                 }
             }
             let mut best_inst: BTreeMap<String, (usize, usize)> = BTreeMap::new();
             for (i, r) in self.rel_places.iter().enumerate() {
                 if let PlaceTarget::Inst(p) = &r.target {
+                    if !anchors.contains_key(&r.owner) {
+                        continue;
+                    }
                     let key = (depth(&r.owner), i);
                     let slot = best_inst.entry(p.clone()).or_insert(key);
                     if key < *slot {

--- a/src/check/generics.rs
+++ b/src/check/generics.rs
@@ -118,7 +118,7 @@ fn example_literal(unit: crate::units::UnitType) -> String {
     }
 }
 
-fn resolve_one(
+pub(crate) fn resolve_one(
     world: &World,
     param: &GenericParam,
     arg: &GenericArg,

--- a/src/check/generics.rs
+++ b/src/check/generics.rs
@@ -82,7 +82,7 @@ pub fn resolve_generic_args(
     subst
 }
 
-fn describe_param(param: &GenericParam) -> String {
+pub(crate) fn describe_param(param: &GenericParam) -> String {
     match &param.bound {
         GenericBound::Unit(u) => format!(
             "`{}` expects a `{}` value (e.g. `{}`)",

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1123,7 +1123,8 @@ impl Server {
             .or_else(|| world.fns.get(&name).map(|f| f.name.span))
             .or_else(|| world.parts.get(&name).map(|p| p.name.span))
             .or_else(|| world.footprints.get(&name).map(|f| f.name.span))
-            .or_else(|| world.pads.get(&name).map(|p| p.name.span))?;
+            .or_else(|| world.pads.get(&name).map(|p| p.name.span))
+            .or_else(|| world.subdesigns.get(&name).map(|s| s.name.span))?;
         Some(lt::Location {
             uri: analysis.uri_for(target.file)?,
             range: span_to_range(&analysis, target),
@@ -1456,6 +1457,7 @@ fn body_pin_refs(body: &[Stmt]) -> Vec<&PinRef> {
             Stmt::Net(s) => out.extend(s.members.iter()),
             Stmt::Nc(s) => out.extend(s.members.iter()),
             Stmt::Call(s) => out.extend(s.args.iter()),
+            Stmt::SubdesignUse(s) => out.extend(s.conns.iter().map(|c| &c.value)),
             _ => {}
         }
     }
@@ -1472,6 +1474,7 @@ fn pin_ref_hover(analysis: &Analysis, fid: FileId, offset: u32) -> Option<lt::Ho
         .values()
         .map(|d| (d.body.as_slice(), None))
         .chain(world.fns.values().map(|f| (f.body.as_slice(), Some(f))))
+        .chain(world.subdesigns.values().map(|s| (s.body.as_slice(), None)))
         .collect();
     for (body, func) in bodies {
         for pr in body_pin_refs(body) {
@@ -1713,6 +1716,14 @@ fn body_inst<'a>(body: &'a [Stmt], name: &str) -> Option<&'a InstStmt> {
     })
 }
 
+/// The RFC-032 use site named `name` in `body`, if any.
+fn body_sub_use<'a>(body: &'a [Stmt], name: &str) -> Option<&'a SubdesignUseStmt> {
+    body.iter().find_map(|s| match s {
+        Stmt::SubdesignUse(u) if u.name.name == name => Some(u),
+        _ => None,
+    })
+}
+
 /// The first named `net` statement in `body` declaring `name`.
 fn body_net_span(body: &[Stmt], name: &str) -> Option<Span> {
     body.iter().find_map(|s| match s {
@@ -1781,19 +1792,39 @@ fn param_trait_names(f: &FnDef, base: &str) -> Vec<String> {
 /// layout-constraint net names (to the net statement).
 fn ref_definition(world: &crate::resolve::World, fid: FileId, offset: u32) -> Option<Span> {
     let hit = |id: &Ident| contains(id.span, fid, offset);
-    let bodies: Vec<(&[Stmt], Option<&FnDef>)> = world
+    let bodies: Vec<(&[Stmt], Option<&FnDef>, Option<&SubdesignDef>)> = world
         .designs
         .values()
-        .map(|d| (d.body.as_slice(), None))
-        .chain(world.fns.values().map(|f| (f.body.as_slice(), Some(f))))
+        .map(|d| (d.body.as_slice(), None, None))
+        .chain(
+            world
+                .fns
+                .values()
+                .map(|f| (f.body.as_slice(), Some(f), None)),
+        )
+        .chain(
+            world
+                .subdesigns
+                .values()
+                .map(|s| (s.body.as_slice(), None, Some(s))),
+        )
         .collect();
-    for (body, func) in bodies {
-        // The instance a reference resolves to: an `inst` in this body, or a
-        // fn parameter (RFC-028 lets physics attrs target Pin/Instance
+    for (body, func, sub) in bodies {
+        // The instance a reference resolves to: an `inst` in this body, a
+        // subdesign use site (RFC-032), a port of the enclosing subdesign, or
+        // a fn parameter (RFC-028 lets physics attrs target Pin/Instance
         // params).
         let inst_target = |id: &Ident| -> Option<Span> {
             if let Some(i) = body_inst(body, &id.name) {
                 return Some(i.name.span);
+            }
+            if let Some(u) = body_sub_use(body, &id.name) {
+                return Some(u.name.span);
+            }
+            if let Some(s) = sub {
+                if let Some(p) = s.ports.iter().find(|p| p.name.name == id.name) {
+                    return Some(p.name.span);
+                }
             }
             func.and_then(|f| {
                 f.params
@@ -1809,6 +1840,16 @@ fn ref_definition(world: &crate::resolve::World, fid: FileId, offset: u32) -> Op
                     .iter()
                     .find(|p| p.name.name == pin.name)
                     .map(|p| p.name.span);
+            }
+            // RFC-032: a use site's ports are its whole pin surface.
+            if let Some(u) = body_sub_use(body, &base.name) {
+                if let Some(sd) = world.subdesigns.get(&u.ty.name.name) {
+                    return sd
+                        .ports
+                        .iter()
+                        .find(|p| p.name.name == pin.name)
+                        .map(|p| p.name.span);
+                }
             }
             let f = func?;
             for tn in param_trait_names(f, &base.name) {
@@ -1898,16 +1939,40 @@ fn ref_definition(world: &crate::resolve::World, fid: FileId, offset: u32) -> Op
                     _ => {}
                 }
             }
-            if let Stmt::Layout(lb) = stmt {
-                for pl in &lb.placements {
-                    // RFC-032: definition on the FIRST path segment only —
-                    // deeper segments live inside another declaration's body.
-                    if let Some(seg) = pl.path.first() {
-                        if hit(&seg.name) {
-                            if let Some(i) = body_inst(body, &seg.name.name) {
-                                return Some(i.name.span);
+            if let Stmt::SubdesignUse(u) = stmt {
+                for conn in &u.conns {
+                    if hit(&conn.port) {
+                        if let Some(sd) = world.subdesigns.get(&u.ty.name.name) {
+                            if let Some(p) = sd.ports.iter().find(|p| p.name.name == conn.port.name)
+                            {
+                                return Some(p.name.span);
                             }
                         }
+                    }
+                }
+            }
+            if let Stmt::Layout(lb) = stmt {
+                for pl in &lb.placements {
+                    // RFC-032: walk the dotted path — each segment before the
+                    // one under the cursor descends through a subdesign use
+                    // site into that subdesign's body.
+                    let mut cur: &[Stmt] = body;
+                    for seg in &pl.path {
+                        if hit(&seg.name) {
+                            if let Some(i) = body_inst(cur, &seg.name.name) {
+                                return Some(i.name.span);
+                            }
+                            if let Some(u) = body_sub_use(cur, &seg.name.name) {
+                                return Some(u.name.span);
+                            }
+                            break;
+                        }
+                        let Some(next) = body_sub_use(cur, &seg.name.name)
+                            .and_then(|u| world.subdesigns.get(&u.ty.name.name))
+                        else {
+                            break;
+                        };
+                        cur = &next.body;
                     }
                 }
                 for c in &lb.constraints {
@@ -2081,6 +2146,15 @@ fn use_site_name(world: &crate::resolve::World, fid: FileId, offset: u32) -> Opt
             return Some(n);
         }
     }
+    // RFC-032: subdesign generic bounds + bodies.
+    for s in world.subdesigns.values() {
+        if let Some(n) = bound_hit(&s.generics) {
+            return Some(n);
+        }
+        if let Some(n) = body_use_site(&s.body, &hit) {
+            return Some(n);
+        }
+    }
     // Footprint pad placements reference pad symbols (RFC-018).
     for fp in world.footprints.values() {
         for place in &fp.pads {
@@ -2131,6 +2205,18 @@ fn body_use_site(body: &[Stmt], hit: &impl Fn(&Ident) -> bool) -> Option<String>
                     return Some(s.callee.name.clone());
                 }
                 for arg in &s.generic_args {
+                    if let GenericArg::Name(id) = arg {
+                        if hit(id) {
+                            return Some(id.name.clone());
+                        }
+                    }
+                }
+            }
+            Stmt::SubdesignUse(s) => {
+                if hit(&s.ty.name) {
+                    return Some(s.ty.name.name.clone());
+                }
+                for arg in &s.ty.generic_args {
                     if let GenericArg::Name(id) = arg {
                         if hit(id) {
                             return Some(id.name.clone());

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -2234,3 +2234,75 @@ fn circular_paste_hover_explains_the_independent_aperture() {
     );
     lsp.shutdown();
 }
+
+// RFC-032 goto-definition (2026-09-08 audit F4): use-site type names, use
+// sites and ports as reference bases, placement reach-in segments, and
+// ordinary references inside a subdesign's own body.
+#[test]
+fn goto_definition_resolves_subdesign_references() {
+    let src = "\
+pub trait ZzIc { designator_prefix: \"U\" }
+pub device ZzReg { pins { VIN: 1 [power_in], VOUT: 2 [power_out] } }
+impl ZzIc for ZzReg {}
+pub subdesign ZzVreg {
+    ports { required VIN: Pin required VOUT: Pin }
+    inst reg: ZzReg
+    net _: VIN, reg.VIN
+    net OUT: VOUT, reg.VOUT
+    layout { place reg at (1mm, 2mm) }
+}
+design ZzB {
+    inst load: ZzReg
+    subdesign vr: ZzVreg { VIN: rail }
+    net rail [5V]: load.VIN
+    net _: vr.VOUT, load.VOUT
+    layout {
+        place vr.reg at (3mm, 4mm)
+    }
+}
+";
+    let (_path, uri, _text) = fixture("subdef.cohdl", src);
+    let mut lsp = Lsp::start();
+    did_open(&mut lsp, &uri, src);
+    let _ = lsp.await_diagnostics(&uri);
+
+    let line = |n: usize| src.lines().nth(n).unwrap();
+    let mut probe = |from_line: usize, needle: &str, to_line: u64, target: &str, what: &str| {
+        let col = line(from_line).find(needle).unwrap() as u64;
+        let def = lsp.request(
+            "textDocument/definition",
+            json!({ "textDocument": { "uri": uri },
+                    "position": { "line": from_line as u64, "character": col + 1 } }),
+        );
+        assert_eq!(def["uri"].as_str(), Some(uri.as_str()), "{what}: {def}");
+        let decl_col = line(to_line as usize).find(target).unwrap() as u64;
+        assert_eq!(
+            def["range"]["start"]["line"].as_u64(),
+            Some(to_line),
+            "{what}: {def}"
+        );
+        assert_eq!(
+            def["range"]["start"]["character"].as_u64(),
+            Some(decl_col),
+            "{what}: {def}"
+        );
+        assert_eq!(
+            def["range"]["end"]["character"].as_u64(),
+            Some(decl_col + target.len() as u64),
+            "{what}: {def}"
+        );
+    };
+
+    // `ZzVreg` in `subdesign vr: ZzVreg { … }` → the subdesign declaration.
+    probe(12, "ZzVreg", 3, "ZzVreg", "use-site type name");
+    // `vr` in `net _: vr.VOUT, …` → the use site.
+    probe(14, "vr", 12, "vr", "use site as reference base");
+    // `VOUT` in `vr.VOUT` → the port declaration.
+    probe(14, "VOUT", 4, "VOUT", "port reference");
+    // `reg` in `place vr.reg` → the inst inside the subdesign body.
+    probe(16, "reg", 5, "reg", "placement reach-in segment");
+    // `reg` in a pin reference inside the subdesign's own body.
+    probe(7, "reg", 5, "reg", "reference inside the declaration body");
+
+    lsp.shutdown();
+}

--- a/tests/subdesign.rs
+++ b/tests/subdesign.rs
@@ -718,3 +718,261 @@ design B {
     assert!(e.contains("E209"), "{e}");
     assert!(e.contains("subdesign"), "the E209 help names the kind: {e}");
 }
+
+// ---------------------------------------------------------------------------
+// 2026-09-08 audit regressions (F1/F2/F3/F5; the LSP finding F4 is pinned in
+// tests/lsp.rs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn physics_attr_through_a_port_is_e1009_never_a_panic() {
+    // Direct: `#[bypass]` names a port inside the subdesign body.
+    let direct = format!(
+        "{LIB}
+subdesign Dec {{
+    ports {{ required V: Pin required G: Pin }}
+    #[bypass(V, 100nF)]
+    inst c: C100N
+    net _: V, c.A
+    net _: G, c.B
+}}
+design B {{
+    inst load: C1U
+    subdesign d: Dec {{ V: load.A, G: load.B }}
+}}
+"
+    );
+    let e = errors_of(&direct);
+    assert!(e.contains("E1009"), "{e}");
+    assert!(
+        e.contains("resolves to a port of subdesign use site"),
+        "{e}"
+    );
+
+    // Indirect: a Pin-typed helper receives the port (RFC-028 binding).
+    let helper = format!(
+        "{LIB}
+fn dec(v: Pin, g: Pin) {{
+    #[bypass(v, 100nF)]
+    inst c: C100N
+    net _: v, c.A
+    net _: g, c.B
+}}
+subdesign Dec {{
+    ports {{ required V: Pin required G: Pin }}
+    dec(V, G)
+}}
+design B {{
+    inst load: C1U
+    subdesign d: Dec {{ V: load.A, G: load.B }}
+}}
+"
+    );
+    let e = errors_of(&helper);
+    assert!(e.contains("E1009"), "{e}");
+
+    // The use site itself as an instance-shaped physics target.
+    let on_site = format!(
+        "{LIB}
+design B {{
+    inst load: C1U
+    subdesign vr: Vreg<100nF> {{ VIN: rail, VOUT: out }}
+    #[bypass(vr, 100nF)]
+    inst c2: C100N
+    net rail [5V]: load.A, c2.A
+    net out: load.B, c2.B
+}}
+"
+    );
+    let e = errors_of(&on_site);
+    assert!(e.contains("E1009"), "{e}");
+
+    // An instance-shaped physics argument naming the use site (RFC-028's
+    // parent-resolution path).
+    let as_parent = format!(
+        "{LIB}
+design B {{
+    inst load: C1U
+    subdesign vr: Vreg<100nF> {{ VIN: rail, VOUT: out }}
+    #[crystal_oscillator(vr, VIN, VOUT)]
+    inst x: C100N
+    net rail [5V]: load.A, x.A
+    net out: load.B, x.B
+}}
+"
+    );
+    let e = errors_of(&as_parent);
+    assert!(e.contains("E1009"), "{e}");
+    assert!(e.contains("`vr` is a subdesign"), "{e}");
+}
+
+#[test]
+fn array_element_name_collisions_are_e201_in_both_directions() {
+    let block = "
+pub subdesign Block {
+    inst c: C100N
+    net _: c.A
+    net _: c.B
+}
+";
+    // A subdesign array's generated element collides with an earlier use
+    // site — before the fix this silently OVERWROTE `B::b_0::c` and lost a
+    // component from the BOM/netlists.
+    let sub_over_sub = format!(
+        "{LIB}{block}
+design B {{
+    subdesign b_0: Block
+    subdesign b: [Block; 2]
+}}
+"
+    );
+    let e = errors_of(&sub_over_sub);
+    assert!(e.contains("E201"), "{e}");
+    assert!(e.contains("`b_0` is already defined in this scope"), "{e}");
+
+    // A physical array's base name colliding with a use site.
+    let inst_over_sub = format!(
+        "{LIB}{block}
+design B {{
+    subdesign b: Block
+    inst b: [C100N; 2]
+}}
+"
+    );
+    let e = errors_of(&inst_over_sub);
+    assert!(e.contains("E201"), "{e}");
+    assert!(e.contains("`b` is already defined in this scope"), "{e}");
+}
+
+#[test]
+fn unused_subdesign_still_validates_nested_use_sites() {
+    // None of these enclosing subdesigns is ever used; the nested use-site
+    // defects are declaration-time facts and must not ship to a consumer.
+    let src = format!(
+        "{LIB}
+subdesign BadUnit {{
+    subdesign child: Vreg<5V>
+}}
+subdesign BadArity {{
+    subdesign child: Vreg<100nF, 5V>
+}}
+subdesign BadPort {{
+    inst c: C1U
+    subdesign child: Vreg<100nF> {{ TYPO: c.A }}
+    net _: c.B
+}}
+design B {{
+    inst load: C1U
+    net rail [5V]: load.A
+    net out: load.B
+}}
+"
+    );
+    let e = errors_of(&src);
+    assert!(e.contains("E112"), "wrong unit must be caught:\n{e}");
+    assert!(e.contains("expected `Capacitance`, found `Voltage`"), "{e}");
+    assert!(e.contains("E401"), "over-arity must be caught:\n{e}");
+    assert!(
+        e.contains("subdesign `Vreg` takes 1 generic argument, but 2 were given"),
+        "{e}"
+    );
+    assert!(e.contains("E1301"), "unknown port must be caught:\n{e}");
+    assert!(
+        e.contains("subdesign `Vreg` (use site `child`) has no port named `TYPO`"),
+        "{e}"
+    );
+}
+
+#[test]
+fn used_subdesign_reports_each_static_defect_once() {
+    // The static pass mirrors expansion's messages EXACTLY so a used
+    // enclosing subdesign collapses under dedup instead of double-reporting.
+    let src = format!(
+        "{LIB}
+subdesign BadUnit {{
+    subdesign child: Vreg<5V>
+}}
+design B {{
+    subdesign bad: BadUnit
+    inst load: C1U
+    net rail [5V]: load.A
+    net out: load.B
+}}
+"
+    );
+    let e = errors_of(&src);
+    assert_eq!(
+        e.matches("wrong unit type").count(),
+        1,
+        "one E112, not a static+expansion double report:\n{e}"
+    );
+}
+
+#[test]
+fn unanchored_outer_override_does_not_shadow_an_anchored_default() {
+    // The audit's F5 shape: `B::o` is unanchored, so its reach-in override
+    // for `inner.c` is inert — but `B::o::inner` IS anchored (design-level
+    // reach-in), and its own default for `c` must still land.
+    let src = format!(
+        "{LIB}
+subdesign Inner {{
+    inst c: C1U
+    net _: c.A
+    net _: c.B
+    layout {{ place c at (1mm, 2mm) }}
+}}
+subdesign Outer {{
+    subdesign inner: Inner
+    layout {{
+        place inner at (10mm, 20mm)
+        place inner.c at (3mm, 4mm)
+    }}
+}}
+design B {{
+    subdesign o: Outer
+    layout {{ place o.inner at (100mm, 200mm) }}
+}}
+"
+    );
+    let c = checked_ok(&src);
+    let ir = c.ir.as_ref().unwrap();
+    let p = place_of(ir, "B::o::inner::c");
+    assert_eq!(
+        (p.at.0.femto, p.at.1.femto),
+        (101_000_000_000_000_000, 202_000_000_000_000_000),
+        "the anchored owner's default composes; the unanchored owner's entry is inert"
+    );
+
+    // The node-anchor side of the same defect: an unanchored grandparent's
+    // whole-unit entry for a node must not shadow the anchored parent's.
+    let src = format!(
+        "{LIB}
+subdesign Inner {{
+    inst c: C1U
+    net _: c.A
+    net _: c.B
+    layout {{ place c at (1mm, 2mm) }}
+}}
+subdesign Mid {{
+    subdesign inner: Inner
+    layout {{ place inner at (7mm, 0mm) }}
+}}
+subdesign Outer {{
+    subdesign mid: Mid
+    layout {{ place mid.inner at (99mm, 99mm) }}
+}}
+design B {{
+    subdesign o: Outer
+    layout {{ place o.mid at (100mm, 200mm) }}
+}}
+"
+    );
+    let c = checked_ok(&src);
+    let ir = c.ir.as_ref().unwrap();
+    let p = place_of(ir, "B::o::mid::inner::c");
+    assert_eq!(
+        (p.at.0.femto, p.at.1.femto),
+        (108_000_000_000_000_000, 202_000_000_000_000_000),
+        "anchor chains through the anchored owner, skipping the inert entry"
+    );
+}

--- a/tests/subdesign.rs
+++ b/tests/subdesign.rs
@@ -884,6 +884,55 @@ design B {{
 }
 
 #[test]
+fn unused_subdesign_validates_argument_kinds_and_trait_bounds() {
+    // The recheck's residual F3 cases: bare numbers, unit literals for
+    // trait-bound parameters, and concrete devices missing the bound are
+    // all declaration-time facts. A name referencing an ENCLOSING generic
+    // is the one legitimately deferred shape.
+    let src = format!(
+        "{LIB}
+pub subdesign NeedsIc<T: Ic> {{
+}}
+subdesign BadNumber {{
+    subdesign child: Vreg<100>
+}}
+subdesign BadKind {{
+    subdesign child: NeedsIc<5V>
+}}
+subdesign BadBound {{
+    subdesign child: NeedsIc<C2T>
+}}
+subdesign Forwards<D: Ic> {{
+    subdesign child: NeedsIc<D>
+}}
+design B {{
+    inst load: C1U
+    net rail [5V]: load.A
+    net out: load.B
+}}
+"
+    );
+    let e = errors_of(&src);
+    assert!(e.contains("E113"), "bare number must be caught:\n{e}");
+    assert!(
+        e.contains("a bare number is never valid for `Cin: Capacitance`"),
+        "{e}"
+    );
+    assert!(
+        e.contains("`T` expects a device type, found unit literal `5V`"),
+        "unit-for-trait must be E403:\n{e}"
+    );
+    assert!(
+        e.matches("E403").count() >= 2,
+        "wrong-trait concrete device must also be E403:\n{e}"
+    );
+    assert!(
+        !e.contains("`D`"),
+        "a name referencing an enclosing generic is deferred, never flagged:\n{e}"
+    );
+}
+
+#[test]
 fn used_subdesign_reports_each_static_defect_once() {
     // The static pass mirrors expansion's messages EXACTLY so a used
     // enclosing subdesign collapses under dedup instead of double-reporting.


### PR DESCRIPTION
An external audit of the RFC-032 subdesign implementation (report in the untracked `artifacts/subdesign-audit-2026-09-08/`) found five issues against a7046b3. All five are fixed here, each with a regression test.

## Fixes

- **F1 — P1, panic**: a physics attribute resolving to a subdesign **port** (directly, or through a `Pin`-typed fn parameter per RFC-028) indexed `ex.instances[path]` with the logical node path and crashed with exit 101. Both resolution paths now emit a targeted **E1009** naming the port / use site. The `SubNode` is registered before its body walks so in-body references identify it precisely.
- **F2 — P1, silent component loss**: subdesign **array elements** bypassed duplicate checking, so `subdesign b_0: Block` + `subdesign b: [Block; 2]` silently overwrote `B::b_0::c` — two components left the BOM/netlists with exit 0. Elements now take the same **E201** check a hand-written declaration gets; the physical-array base-name guard also checks `local_subs`/`bindings` (closing the `subdesign b: Block` + `inst b: [C100N; 2]` asymmetry).
- **F3 — P2**: nested use sites inside an **unused** subdesign escaped statically knowable validation. `check_fn_bodies` now validates target kind, variant selector, generic arity + concrete unit literals, and connection port keys (**E205/E1303/E401/E112/E1301**), with messages mirroring expansion's exactly — a used enclosing subdesign dedups to a single report (pinned by test).
- **F4 — P2**: LSP goto-definition learned subdesigns: use-site type names, use sites and ports as reference bases, connection port keys, placement reach-in segments (walking through subdesign bodies), and references inside a subdesign's own body.
- **F5 — P2, silent placement loss**: the placement finalizer selected the outermost per-target entry **before** checking its owner was anchored, so an inert entry in an unanchored ancestor's layout shadowed a usable anchored default and the part was staged. Both selection loops now select only among anchored-owner entries; regression covers both the per-instance and node-anchor sides.

## Also

- Re-locks `examples/joint-motor-controller`: `lib/can`/`lib/motor-driver` gained their vendored datasheets after the example's `cohdl.lock` was generated within the same commit, so a clean checkout failed **E1103**. Only the two hashes change.

## Verification

- Audit runner: **30/30** (was 21/30), exit 0
- `cargo test`: **634 green** (628 baseline + 6 new regressions)
- `cargo fmt --check` + `clippy --all-targets -D warnings` clean
- All three examples rebuilt in a scratch tree: every manifest-listed artifact and `design.lock` **byte-identical**

🤖 Generated with [Claude Code](https://claude.com/claude-code)