### PR TITLE
release: CoHDL 0.7.0 — RFC-032 subdesigns, joint-motor example, Zed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cohdl"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "lsp-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohdl"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "CoHDL v2 — the AI-native PCB schematic language compiler"
 license = "MIT"

--- a/site/public/blog/cohdl-0-7-0/index.html
+++ b/site/public/blog/cohdl-0-7-0/index.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#070b11" />
+    <title>CoHDL 0.7.0: Subdesigns and a Zed Extension</title>
+    <meta
+      name="description"
+      content="CoHDL 0.7.0 introduces subdesign — reusable, typed circuit blocks with explicit port boundaries and their own default layout — plus a CAN joint-motor-controller example built from them, and a Zed editor extension."
+    />
+    <link
+      rel="canonical"
+      href="https://cohdl.org/blog/cohdl-0-7-0/"
+    />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="CoHDL" />
+    <meta
+      property="og:title"
+      content="CoHDL 0.7.0: Subdesigns and a Zed Extension"
+    />
+    <meta
+      property="og:description"
+      content="Reusable, typed circuit blocks: ports are the only electrical surface, the container never becomes a component, and each block carries a default layout the board transforms as one unit."
+    />
+    <meta property="og:url" content="https://cohdl.org/blog/cohdl-0-7-0/" />
+    <meta property="og:image" content="https://cohdl.org/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary" />
+
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/css/style.css" />
+    <link rel="stylesheet" href="/css/prose.css" />
+    <link rel="alternate" type="application/atom+xml" title="CoHDL blog" href="/blog/feed.xml" />
+
+    <!-- Google tag (gtag.js) — bootstrap lives in /js/analytics.js so the CSP
+         needs no inline-script allowance. -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R73M37GXP7"></script>
+    <script src="/js/analytics.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div class="shell">
+      <header class="masthead">
+        <a class="brand" href="/">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span class="brand-word">CoHDL</span>
+        </a>
+        <nav class="site-nav" aria-label="Site">
+          <a class="site-nav-link" href="/docs/">Docs</a>
+          <a class="site-nav-link" href="/blog/" aria-current="page">Blog</a>
+          <a class="site-nav-link" href="/use-cases/">Use cases</a>
+          <a class="site-nav-link" href="https://registry.cohdl.org">Registry</a>
+        </nav>
+      </header>
+
+      <main id="main">
+        <div class="page-head">
+          <ol class="crumbs">
+            <li><a href="/blog/">Blog</a></li>
+            <li aria-current="page">CoHDL 0.7.0</li>
+          </ol>
+          <h1 class="page-title">
+            CoHDL 0.7.0: Subdesigns<br /><em>and a Zed Extension</em>
+          </h1>
+          <p class="page-lede">
+            Circuits become reusable, typed building blocks: a
+            <code>subdesign</code> exposes ports, keeps its internals behind them,
+            and carries its own default layout onto the board as one placed unit.
+          </p>
+          <p class="post-meta">
+            Tony Huang <span class="sep">·</span>
+            <time datetime="2026-09-08">September 8, 2026</time>
+          </p>
+        </div>
+
+        <article class="prose">
+          <p>
+            CoHDL 0.7.0 is out — <code>cohdl self-update</code> if you have it, or:
+          </p>
+          <pre><code>curl -fsSL https://raw.githubusercontent.com/conol-ai/cohdl/main/install.sh | sh</code></pre>
+
+          <h2>Subdesigns: typed composition for circuits</h2>
+          <p>
+            Every board has regions that are really one thing — a regulator and
+            its passives, a transceiver and its termination, an H-bridge and its
+            sense network. Until now CoHDL could reuse those only as
+            <code>fn</code> expansions: real components, but no boundary. The new
+            <code>subdesign</code> declaration (RFC-032) makes the boundary part of
+            the type system. Ports are the <em>only</em> electrical surface —
+            internals cannot be reached from outside — and each port carries the
+            same connection obligations a device pin does, so an unconnected
+            required port is a compile error at the use site, not a surprise at
+            bring-up.
+          </p>
+          <pre><code>subdesign MotorStage {
+    ports {
+        required IN1: Pin
+        required IN2: Pin
+        required VM: Pin
+        required GND: Pin
+    }
+
+    inst drv: motor_driver::MOTOR_DRV8231A
+    #[bypass(drv.VM, 100nF)]
+    inst c_vm_hf: passive::C_100n_10V_X5R_0402
+    inst c_vm_bulk_b: passive::C_10u_25V_X5R_0805
+
+    net _: IN1, drv.IN1
+    net _: IN2, drv.IN2
+    net _: VM, drv.VM, c_vm_hf.A, c_vm_bulk_b.A
+    net _: GND, drv.GND, c_vm_hf.B, c_vm_bulk_b.B
+
+    layout {
+        place drv at (0mm, 0mm)
+        place c_vm_hf at (-4mm, -1mm) rotate 90
+    }
+}
+
+design JointMC {
+    subdesign motor: MotorStage
+    net VBAT [7.4V]: conn_pwr.P1, motor.VM
+
+    layout {
+        place motor at (12mm, -6mm) rotate 90
+        // This board only: pull the bulk capacitor into the
+        // motor connector's current loop.
+        place motor.c_vm_bulk_b at (16.5mm, -2mm) rotate 90
+    }
+}</code></pre>
+          <p>
+            The container itself never becomes a component: no designator, no BOM
+            row, no netlist entry. Ports dissolve into the nets they join, and what
+            reaches manufacturing is exactly the flat design you would have written
+            by hand — same designators, same bytes. Hierarchy survives where it
+            helps: instances keep <code>Design::use::inst</code> paths, generics and
+            arrays work on subdesigns exactly as they do on devices
+            (<code>subdesign vr: Vreg&lt;100nF&gt;</code>,
+            <code>[CanPort;&nbsp;2]</code>), and subdesigns nest.
+          </p>
+          <p>
+            Layout composes the same way. A subdesign's internal
+            <code>layout {}</code> is a <em>default</em>: place the use site and
+            the whole cluster lands translated, rotated, and mirrored as one unit
+            — the back-side math is the same pad arithmetic the KiCad emitter is
+            verified against. When one board needs one component somewhere else,
+            <code>place motor.c_vm_bulk_b at …</code> reaches through the boundary
+            for placement only — explicit beats the default, and the electrical
+            surface stays sealed.
+          </p>
+
+          <h2>A joint motor controller, built from blocks</h2>
+          <p>
+            The <a
+              href="https://github.com/conol-ai/cohdl/tree/main/examples/joint-motor-controller"
+              >new third example</a
+            > is a daisy-chainable CAN&nbsp;2.0B joint node for a 2S pack: an
+            STM32F072 with three subdesign regions around it — a JW5033S buck
+            running the datasheet application verbatim, an SN65HVD230 CAN port in
+            slope-control mode, and a DRV8231A H-bridge that regulates its own
+            stall current with no firmware in the loop. Both existing examples were
+            refactored onto subdesigns too, byte-identical outputs before and
+            after. New library packages back it:
+            <a href="https://registry.cohdl.org/packages/can">can</a>,
+            <a href="https://registry.cohdl.org/packages/motor-driver">motor-driver</a>,
+            and Micro-Fit&nbsp;3.0 connectors, each with vendored datasheets and
+            audited lands.
+          </p>
+
+          <h2>Hardened by review</h2>
+          <p>
+            The subdesign implementation went through an independent adversarial
+            audit — thirty CLI and LSP probes against the shipped compiler — and a
+            follow-up recheck. Every finding is closed and pinned by regression
+            tests: a crash on physics attributes reaching a port, two silent
+            component-loss paths, validation that used to wait for instantiation
+            (a library now fails its own check rather than shipping a broken
+            generic to its consumer), go-to-definition across subdesign
+            boundaries, and a placement-precedence edge where an inert outer
+            override could shadow a real default. The audit's own runners now pass
+            44/44.
+          </p>
+
+          <h2>CoHDL in Zed</h2>
+          <p>
+            Alongside the <a href="/docs/editors/">VS Code extension</a>, the
+            repository now carries a
+            <a href="https://github.com/conol-ai/cohdl/tree/main/editors/zed"
+              >Zed extension</a
+            >: a tree-sitter grammar (validated against every source file in the
+            repository) plus the same <code>cohdl lsp</code> server — diagnostics
+            as you type, hover, go-to-definition, find-references. It finds
+            <code>cohdl</code> on your PATH or downloads the matching release on
+            its own. Until it lands in the Zed registry, install it as a dev
+            extension: <strong>Extensions → Install Dev Extension</strong> →
+            <code>editors/zed</code> in a checkout.
+          </p>
+
+          <p>
+            Full source and design record:
+            <a href="https://github.com/conol-ai/cohdl">github.com/conol-ai/cohdl</a>.
+          </p>
+        </article>
+      </main>
+
+      <footer class="footer">
+        <p class="footer-line">
+          <span class="footer-brand">CoHDL</span>
+          <span class="footer-sep" aria-hidden="true">·</span>
+          <a href="/docs/">Docs</a>
+          <span class="footer-sep" aria-hidden="true">·</span>
+          <a href="/blog/">Blog</a>
+          <span class="footer-sep" aria-hidden="true">·</span>
+          <a href="/use-cases/">Use cases</a>
+          <span class="footer-sep" aria-hidden="true">·</span>
+          <a href="https://registry.cohdl.org">Package registry</a>
+          <span class="footer-sep" aria-hidden="true">·</span>
+          <a
+            href="https://discord.gg/x7DXPvK66"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Join on Discord (opens in a new tab)"
+          >Join on Discord <span aria-hidden="true">↗</span></a>
+        </p>
+        <p class="footer-fine">A project by Conol.</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/site/public/blog/feed.xml
+++ b/site/public/blog/feed.xml
@@ -5,8 +5,16 @@
   <id>https://cohdl.org/blog/feed.xml</id>
   <link rel="alternate" type="text/html" href="https://cohdl.org/blog/" />
   <link rel="self" type="application/atom+xml" href="https://cohdl.org/blog/feed.xml" />
-  <updated>2026-09-01T02:00:00Z</updated>
+  <updated>2026-09-08T13:30:00Z</updated>
   <author><name>Tony Huang</name></author>
+  <entry>
+    <title>CoHDL 0.7.0: Subdesigns and a Zed Extension</title>
+    <link href="https://cohdl.org/blog/cohdl-0-7-0/" />
+    <id>https://cohdl.org/blog/cohdl-0-7-0/</id>
+    <published>2026-09-08T13:30:00Z</published>
+    <updated>2026-09-08T13:30:00Z</updated>
+    <summary>Circuits become reusable, typed building blocks: subdesign exposes ports, keeps its internals behind them, and carries its own default layout onto the board as one placed unit — plus a CAN joint-motor-controller example and a Zed extension.</summary>
+  </entry>
   <entry>
     <title>CoHDL 0.6.0: An EasyEDA Backend and the STM32 Catalog</title>
     <link href="https://cohdl.org/blog/cohdl-0-6-0/" />

--- a/site/public/blog/index.html
+++ b/site/public/blog/index.html
@@ -65,6 +65,22 @@
           <ul class="post-list">
             <li class="post-item">
               <p class="post-item-date">
+                <time datetime="2026-09-08">September 8, 2026</time>
+              </p>
+              <h2 class="post-item-title">
+                <a href="/blog/cohdl-0-7-0/"
+                  >CoHDL 0.7.0: Subdesigns and a Zed Extension</a
+                >
+              </h2>
+              <p class="post-item-excerpt">
+                Circuits become reusable, typed building blocks: a subdesign
+                exposes ports, keeps its internals behind them, and carries its
+                own default layout onto the board as one placed unit. Plus a CAN
+                joint-motor-controller example and CoHDL support in Zed.
+              </p>
+            </li>
+            <li class="post-item">
+              <p class="post-item-date">
                 <time datetime="2026-09-01">September 1, 2026</time>
               </p>
               <h2 class="post-item-title">


### PR DESCRIPTION
The 0.7.0 release commit: `Cargo.toml`/`Cargo.lock` bump plus the release post at `/blog/cohdl-0-7-0/` (blog index + Atom feed wired; the site deploys from main).

Release contents since v0.6.0: RFC-032 `subdesign` (PR #35), the joint-motor-controller example + `can`/`motor-driver`/Micro-Fit packages, both audit passes closed (PR #36), and the Zed extension + `zed-v*` release track (PR #37).

After merge: tag `v0.7.0` on the merge commit → `release-cohdl.yml` builds the five targets, signs/notarizes the macOS binaries, and publishes.

Gates on this tree: fmt/clippy clean, 635 tests green, feed XML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)