### PR TITLE
CoHDL 0.7.1: fix array elements passed to instance parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cohdl"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "lsp-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cohdl"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "CoHDL v2 — the AI-native PCB schematic language compiler"
 license = "MIT"

--- a/explorer/extractor/Cargo.lock
+++ b/explorer/extractor/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cohdl"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "lsp-types",
  "serde",

--- a/src/check/bodies.rs
+++ b/src/check/bodies.rs
@@ -463,9 +463,10 @@ fn check_call_kind(world: &World, callee: &crate::ast::Ident, diags: &mut Diagno
     // Unresolved: already reported at the rewrite pass (E504).
 }
 
-/// Call value-argument count (vs the fn's `Pin` parameters) and each
-/// argument's reference base (E502 arity, mirrors expansion; unknown bases
-/// reuse the pin-ref path).
+/// Call value-argument count and reference kinds, using the callee's parameter
+/// types. A whole instance is valid for an instance parameter; only a `Pin`
+/// parameter requires a pin reference. Bounds and selectors are checked at
+/// expansion, as for net/nc references in this pass.
 fn check_call_args(
     world: &World,
     _f: &FnDef,
@@ -473,7 +474,8 @@ fn check_call_args(
     bases: &BTreeMap<&str, Base>,
     diags: &mut Diagnostics,
 ) {
-    if let Some(callee) = world.fns.get(&call.callee.name) {
+    let callee = world.fns.get(&call.callee.name);
+    if let Some(callee) = callee {
         if call.args.len() != callee.params.len() {
             diags.push(Diagnostic::error(
                 "E502",
@@ -488,8 +490,36 @@ fn check_call_args(
             ));
         }
     }
-    for arg in &call.args {
-        check_pin_ref(world, bases, arg, diags);
+    for (i, arg) in call.args.iter().enumerate() {
+        match callee.and_then(|f| f.params.get(i)).map(|p| &p.ty) {
+            Some(FnParamTy::Generic(_) | FnParamTy::ImplTrait(..)) => {
+                if arg.pin.is_some() {
+                    diags.push(Diagnostic::error(
+                        "E503",
+                        arg.span,
+                        format!("expected an instance, found pin reference `{}`", arg),
+                    ));
+                } else {
+                    match bases.get(arg.base.name.as_str()) {
+                        Some(Base::Concrete(..) | Base::Abstract) => {}
+                        Some(Base::Pin) => diags.push(Diagnostic::error(
+                            "E503",
+                            arg.span,
+                            format!(
+                                "expected an instance, but `{}` is a `Pin` parameter",
+                                arg.base.name
+                            ),
+                        )),
+                        None | Some(Base::Sub { .. }) => diags.push(Diagnostic::error(
+                            "E202",
+                            arg.base.span,
+                            format!("unknown instance `{}` in this scope", arg.base.name),
+                        )),
+                    }
+                }
+            }
+            _ => check_pin_ref(world, bases, arg, diags),
+        }
     }
 }
 

--- a/src/check/expand.rs
+++ b/src/check/expand.rs
@@ -15,6 +15,7 @@ use crate::ir::{
 use crate::resolve::World;
 use crate::span::Span;
 use crate::units::UnitValue;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 
 pub fn expand_design(world: &World, design: &DesignDef, diags: &mut Diagnostics) -> DesignIr {
@@ -1284,15 +1285,14 @@ impl<'w, 'd> Expander<'w, 'd> {
             .collect()
     }
 
-    fn resolve_pin_ref(&mut self, r: &PinRef, scope: &Scope) -> Option<(String, String)> {
-        // RFC-024: resolve an array-typed reference to its one real element.
-        // `NAME[i]` is valid in EVERY position an ordinary instance reference
-        // is; only the range/list fan-out sugar is net-member-only, and that
-        // has already been expanded to `Single`s by `handle_net`.
+    /// RFC-024: resolve one reference's selector before looking up its base.
+    /// Pin references and instance arguments must share the same element
+    /// identity and validation. Net-member fan-out is expanded by `handle_net`
+    /// before reaching this single-element resolver.
+    fn resolve_array_ref<'r>(&mut self, r: &'r PinRef, scope: &Scope) -> Option<Cow<'r, PinRef>> {
         let array = scope.arrays.get(&r.base.name).copied();
-        let owned;
-        let r = match (&r.index, array) {
-            (None, None) => r,
+        match (&r.index, array) {
+            (None, None) => Some(Cow::Borrowed(r)),
             (None, Some(_)) => {
                 self.diags.push(Diagnostic::error(
                     "E211",
@@ -1302,7 +1302,7 @@ impl<'w, 'd> Expander<'w, 'd> {
                         r.base.name, r.base.name
                     ),
                 ));
-                return None;
+                None
             }
             (Some(sel), None) => {
                 self.diags.push(Diagnostic::error(
@@ -1313,7 +1313,7 @@ impl<'w, 'd> Expander<'w, 'd> {
                         r.base.name
                     ),
                 ));
-                return None;
+                None
             }
             (Some(sel), Some((n, _))) => {
                 let IndexSel::Single(i, _) = sel else {
@@ -1328,7 +1328,7 @@ impl<'w, 'd> Expander<'w, 'd> {
                     return None;
                 };
                 self.array_bounds(&r.base, sel, n)?;
-                owned = PinRef {
+                Some(Cow::Owned(PinRef {
                     base: Ident {
                         name: element_name(&r.base.name, *i),
                         span: r.base.span,
@@ -1336,10 +1336,13 @@ impl<'w, 'd> Expander<'w, 'd> {
                     index: None,
                     pin: r.pin.clone(),
                     span: r.span,
-                };
-                &owned
+                }))
             }
-        };
+        }
+    }
+
+    fn resolve_pin_ref(&mut self, r: &PinRef, scope: &Scope) -> Option<(String, String)> {
+        let r = self.resolve_array_ref(r, scope)?;
         // Base: a fn parameter binding?
         if let Some(binding) = scope.bindings.get(&r.base.name) {
             return match (binding, &r.pin) {
@@ -2159,6 +2162,7 @@ impl<'w, 'd> Expander<'w, 'd> {
             ));
             return None;
         }
+        let arg = self.resolve_array_ref(arg, scope)?;
         if let Some(binding) = scope.bindings.get(&arg.base.name) {
             return match binding {
                 Binding::Instance { path, device, .. } => Some((path.clone(), device.clone())),

--- a/tests/inst_array.rs
+++ b/tests/inst_array.rs
@@ -15,6 +15,7 @@
 
 use cohdl::lock::LockState;
 use cohdl::pipeline::{build_artifacts, check_files_in};
+use std::collections::BTreeSet;
 
 fn check(src: &str) -> (cohdl::pipeline::Checked, String) {
     let files = vec![("src/main.cohdl".to_string(), src.to_string())];
@@ -167,6 +168,347 @@ design B {{
     );
     let (_c, rendered) = check(&src);
     assert!(!rendered.contains("error"), "{}", rendered);
+}
+
+const TWO_PIN: &str = r#"
+trait TwoPin { pins { required A: pin, required B: pin } }
+device Element { pins { required A: 1 [passive], required B: 2 [passive] } }
+impl TwoPin for Element {}
+"#;
+
+const INSTANCE_FNS: [(&str, &str); 2] = [
+    ("fn tie(x: impl TwoPin)", "tie"),
+    ("fn tie<T: TwoPin>(x: T)", "tie::<Element>"),
+];
+
+#[test]
+fn indexed_instance_arguments_connect_distinct_elements() {
+    // Issue #41: indexed Pin arguments worked, but whole instances did not.
+    // Both elements and the scalar control must retain their own identity.
+    for (header, callee) in INSTANCE_FNS {
+        let src = format!(
+            "{TWO_PIN}
+{header} {{ net _: x.A, x.B }}
+design Demo {{
+    inst xs: [Element; 2]
+    inst scalar: Element
+    {callee}(xs[0])
+    {callee}(xs[1])
+    {callee}(scalar)
+}}"
+        );
+        let (checked, rendered) = check(&src);
+        assert!(!checked.diags.has_errors(), "{header}:\n{rendered}");
+        let ir = checked.ir.unwrap();
+        assert_eq!(ir.instances.len(), 3);
+        assert_eq!(ir.nets.len(), 3);
+        for path in ["Demo::xs_0", "Demo::xs_1", "Demo::scalar"] {
+            let expected = BTreeSet::from([(path.into(), "A".into()), (path.into(), "B".into())]);
+            assert!(
+                ir.nets.iter().any(|n| n.members == expected),
+                "{header}: {path}"
+            );
+        }
+    }
+}
+
+#[test]
+fn indexed_instance_arguments_emit_like_explicit_instances() {
+    for (header, callee) in INSTANCE_FNS {
+        let src = format!(
+            "{TWO_PIN}
+footprint FP {{}}
+part EL: Element {{ primary {{ mfr: \"m\", mpn: \"el\", footprint: FP }} }}
+{header} {{ net _: x.A, x.B }}
+design Demo {{
+    inst xs: [EL; 2]
+    {callee}(xs[0])
+    {callee}(xs[1])
+}}"
+        );
+        let explicit = src
+            .replace("inst xs: [EL; 2]", "inst xs_0: EL\n    inst xs_1: EL")
+            .replace("xs[0]", "xs_0")
+            .replace("xs[1]", "xs_1");
+        assert_eq!(netlist(&src), netlist(&explicit), "{header}");
+    }
+}
+
+#[test]
+fn indexed_instance_arguments_work_in_nested_scopes() {
+    for (header, callee) in INSTANCE_FNS {
+        let src = format!(
+            "{TWO_PIN}
+{header} {{ net _: x.A, x.B }}
+fn relay(x: impl TwoPin) {{ {callee}(x) }}
+fn populate() {{
+    inst xs: [Element; 2]
+    relay(xs[0])
+    relay(xs[1])
+}}
+subdesign Block {{
+    inst xs: [Element; 2]
+    relay(xs[0])
+    relay(xs[1])
+}}
+design Demo {{
+    populate()
+    subdesign block: Block
+}}"
+        );
+        let (checked, rendered) = check(&src);
+        assert!(!checked.diags.has_errors(), "{header}:\n{rendered}");
+        let ir = checked.ir.unwrap();
+        assert_eq!(ir.instances.len(), 4);
+        assert_eq!(ir.nets.len(), 4);
+        for path in ir.instances.keys() {
+            let expected = BTreeSet::from([(path.clone(), "A".into()), (path.clone(), "B".into())]);
+            assert!(
+                ir.nets.iter().any(|n| n.members == expected),
+                "{header}: {path}"
+            );
+        }
+    }
+}
+
+#[test]
+fn instance_argument_selectors_are_validated() {
+    for (header, callee) in INSTANCE_FNS {
+        for (arg, code, message) in [
+            ("xs[2]", "E202", "valid indices are 0..=1 (length 2)"),
+            ("xs[99]", "E202", "valid indices are 0..=1 (length 2)"),
+            ("xs", "E211", "reference one element, e.g. `xs[0]`"),
+            ("xs[0..=1]", "E211", "only valid in a net's member list"),
+            ("xs[0, 1]", "E211", "only valid in a net's member list"),
+            (
+                "scalar[0]",
+                "E211",
+                "`scalar` is not an array-typed instance",
+            ),
+            (
+                "scalar[99]",
+                "E211",
+                "`scalar` is not an array-typed instance",
+            ),
+            (
+                "scalar[0..=1]",
+                "E211",
+                "`scalar` is not an array-typed instance",
+            ),
+            (
+                "scalar[0, 1]",
+                "E211",
+                "`scalar` is not an array-typed instance",
+            ),
+        ] {
+            let src = format!(
+                "{TWO_PIN}
+{header} {{ net _: x.A, x.B }}
+design Demo {{
+    inst xs: [Element; 2]
+    inst scalar: Element
+    {callee}({arg})
+    net _: xs[0].A, xs[0].B
+    net _: xs[1].A, xs[1].B
+    net _: scalar.A, scalar.B
+}}"
+            );
+            let (checked, rendered) = check(&src);
+            // Wiring the pins separately isolates the argument diagnostic.
+            assert_eq!(
+                checked.diags.error_count(),
+                1,
+                "{header} / {arg}:\n{rendered}"
+            );
+            let diagnostic = checked
+                .diags
+                .iter()
+                .find(|d| d.code == code)
+                .unwrap_or_else(|| panic!("{header} / {arg}: expected {code}:\n{rendered}"));
+            assert!(
+                diagnostic.message.contains(message),
+                "{header} / {arg}:\n{rendered}"
+            );
+            let span = diagnostic.primary.span;
+            let highlighted = &src[span.start as usize..span.end as usize];
+            assert_eq!(highlighted, arg.find('[').map_or(arg, |i| &arg[i..]));
+        }
+    }
+}
+
+#[test]
+fn forwarded_instance_arguments_cannot_be_indexed() {
+    for (header, callee) in INSTANCE_FNS {
+        for arg in ["x[99]", "x[0..=1]", "x[0, 1]"] {
+            let src = format!(
+                "{TWO_PIN}
+{header} {{ net _: x.A, x.B }}
+fn relay(x: impl TwoPin) {{ {callee}({arg}) }}
+design Demo {{
+    inst scalar: Element
+    relay(scalar)
+    net _: scalar.A, scalar.B
+}}"
+            );
+            let (checked, rendered) = check(&src);
+            assert_eq!(
+                checked.diags.error_count(),
+                1,
+                "{header} / {arg}:\n{rendered}"
+            );
+            assert!(
+                rendered.contains("E211")
+                    && rendered.contains("`x` is not an array-typed instance"),
+                "{header} / {arg}:\n{rendered}"
+            );
+        }
+    }
+}
+
+#[test]
+fn indexed_instance_arguments_preserve_trait_bounds() {
+    for (header, callee) in INSTANCE_FNS {
+        let lib = TWO_PIN.replace("impl TwoPin for Element {}", "");
+        let src = format!(
+            "{lib}
+{header} {{ net _: x.A, x.B }}
+design Demo {{
+    inst xs: [Element; 1]
+    {callee}(xs[0])
+    net _: xs[0].A, xs[0].B
+}}"
+        );
+        let (checked, rendered) = check(&src);
+        assert_eq!(checked.diags.error_count(), 1, "{header}:\n{rendered}");
+        assert!(
+            rendered.contains("E403") && rendered.contains("`Element` does not implement `TwoPin`"),
+            "{header}:\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn indexed_instance_arguments_preserve_generic_device_matching() {
+    let src = format!(
+        "{TWO_PIN}
+device Other {{ pins {{ required A: 1 [passive], required B: 2 [passive] }} }}
+impl TwoPin for Other {{}}
+fn tie<T: TwoPin>(x: T) {{ net _: x.A, x.B }}
+design Demo {{
+    inst xs: [Other; 1]
+    tie::<Element>(xs[0])
+    net _: xs[0].A, xs[0].B
+}}"
+    );
+    let (checked, rendered) = check(&src);
+    assert_eq!(checked.diags.error_count(), 1, "{rendered}");
+    assert!(
+        rendered.contains("E503")
+            && rendered.contains("expects an instance of")
+            && rendered.contains("Element")
+            && rendered.contains("Other"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn indexed_instance_arguments_preserve_pin_obligations() {
+    for (header, callee) in INSTANCE_FNS {
+        let src = format!(
+            "{TWO_PIN}
+{header} {{ nc: x.A }}
+design Demo {{
+    inst xs: [Element; 1]
+    {callee}(xs[0])
+}}"
+        );
+        let (checked, rendered) = check(&src);
+        assert_eq!(checked.diags.error_count(), 1, "{header}:\n{rendered}");
+        assert!(
+            rendered.contains("E701")
+                && rendered.contains("required pin `Demo::xs_0.B` is unresolved"),
+            "{header}:\n{rendered}"
+        );
+        assert!(checked
+            .ir
+            .unwrap()
+            .nc_pins
+            .contains(&("Demo::xs_0".into(), "A".into())));
+    }
+}
+
+#[test]
+fn instance_arguments_still_reject_indexed_pins() {
+    for (header, callee) in INSTANCE_FNS {
+        let src = format!(
+            "{TWO_PIN}
+{header} {{ net _: x.A, x.B }}
+design Demo {{
+    inst xs: [Element; 1]
+    {callee}(xs[0].A)
+    net _: xs[0].A, xs[0].B
+}}"
+        );
+        let (checked, rendered) = check(&src);
+        assert_eq!(checked.diags.error_count(), 1, "{header}:\n{rendered}");
+        assert!(
+            rendered.contains("E503")
+                && rendered.contains("expected an instance, found pin reference `xs[0].A`"),
+            "{header}:\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn unused_bodies_check_instance_argument_kinds() {
+    for (header, callee) in INSTANCE_FNS {
+        for (params, body, arg, code, message) in [
+            (
+                "",
+                "inst xs: [Element; 1]",
+                "xs[0].A",
+                "E503",
+                "expected an instance, found pin reference `xs[0].A`",
+            ),
+            (
+                "p: Pin",
+                "",
+                "p",
+                "E503",
+                "expected an instance, but `p` is a `Pin` parameter",
+            ),
+            (
+                "",
+                "",
+                "missing",
+                "E202",
+                "unknown instance `missing` in this scope",
+            ),
+        ] {
+            let src = format!(
+                "{TWO_PIN}
+{header} {{ net _: x.A, x.B }}
+fn unused({params}) {{
+    {body}
+    {callee}({arg})
+}}
+design Demo {{}}"
+            );
+            let (checked, rendered) = check(&src);
+            assert_eq!(
+                checked.diags.error_count(),
+                1,
+                "{header} / {arg}:\n{rendered}"
+            );
+            assert!(
+                checked
+                    .diags
+                    .iter()
+                    .any(|d| d.code == code && d.message == message),
+                "{header} / {arg}:\n{rendered}"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Array elements such as `tie(xs[0])` failed with `E202` when passed to an instance-typed function parameter. Both `impl Trait` and explicit trait-bound generic parameters now resolve the real element through the same selector validation used by pin references. Bare arrays, scalar indexing, and range/list fan-out are rejected, and out-of-bounds diagnostics name the valid range.

Declaration-time checking now follows the callee's parameter kind, so valid instance arguments also work inside functions and subdesigns. Ten new regression tests cover both parameter forms, nested scopes and forwarding, invalid selectors and diagnostic spans, trait and concrete-device checks, required-pin obligations, and byte-identical netlists against explicit scalar instances.

This bumps the compiler to 0.7.1 and synchronizes both Cargo lock files. After merge, the `v0.7.1` tag will publish the patch through the existing five-platform release workflow.

Validation: full compiler suite (646 passed, 1 ignored), all 6 Explorer extractor tests, formatting, and Clippy. The original issue reproduction passes with no CLI JSON diagnostics.

Fixes #41.
